### PR TITLE
v2026.19 - Enterprise API

### DIFF
--- a/enterprise-api/schema.graphql
+++ b/enterprise-api/schema.graphql
@@ -4,1319 +4,2603 @@ directive @FsDBReadOnly on FIELD_DEFINITION
 Directs the executor to defer this fragment when the `if` argument is true or undefined.
 """
 directive @defer(
-    """
-    Deferred when true or undefined.
-    """
-    if: Boolean = true
+	"""
+	Deferred when true or undefined.
+	"""
+	if: Boolean = true
 
-    """
-    Unique name
-    """
-    label: String
+	"""
+	Unique name
+	"""
+	label: String
 ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
 
 directive @fsValidation(
-    constraint: String!
+	constraint: String!
 ) on INPUT_FIELD_DEFINITION | ARGUMENT_DEFINITION | FIELD_DEFINITION
 
 directive @goExtraField(
-    name: String
-    type: String!
-    overrideTags: String
-    description: String
+	name: String
+	type: String!
+	overrideTags: String
+	description: String
 ) on OBJECT | INPUT_OBJECT
 
 directive @goField(
-    forceResolver: Boolean
-    name: String
+	forceResolver: Boolean
+	name: String
 ) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
+
+type AIInsights {
+	status: AIInsightsStatus!
+	summary: String
+	generatedAt: Time
+}
+
+enum AIInsightsStatus {
+	GENERATING
+	GENERATED
+	FAILED
+	DIRTY
+}
+
+type AdaptationSummaryData {
+	"""
+	Socio-economic pathway of the prediction model.
+	"""
+	ssp: SSP
+
+	"""
+	The relative year with current year being year 0.
+	"""
+	year: Int
+
+	"""
+	Hold Period of the asset in years.
+	"""
+	holdPeriod: Int
+
+	"""
+	Percentile value for estimates (10, 50, or 90).
+	"""
+	percentile: Int
+
+	"""
+	Total baseline loss on the places with adaptations planned.
+	"""
+	baselineLoss: Int64
+
+	"""
+	Total adapted loss on the places with adaptations planned.
+	"""
+	adaptedLoss: Int64
+
+	"""
+	Total savings on investment due to the adaptations planned.
+	"""
+	adaptationSOI: Int64
+
+	"""
+	Total cumulative cost of the adaptations planned.
+	"""
+	cumulativeCost: Int64
+
+	"""
+	Payback period in years for the adaptations planned.
+	"""
+	paybackYear: Int
+}
+
+enum AdaptationType {
+	FLOOD_BARRIER_TO_1_FOOT
+	FLOOD_BARRIER_TO_2_FEET
+	FLOOD_BARRIER_TO_3_FEET
+	FLOOD_BARRIER_TO_4_FEET
+	FLOOD_BARRIER_TO_5_FEET
+	FLOOD_BARRIER_TO_6_FEET
+	FLOOD_BARRIER_TO_7_FEET
+	FLOOD_BARRIER_TO_8_FEET
+	FIRE_PROOFING
+	DEFENSIBLE_SPACE
+	WIND_DESIGN_STANDARD_LOW_TO_MEDIUM
+	WIND_DESIGN_STANDARD_MEDIUM_TO_HIGH
+	WIND_DESIGN_STANDARD_LOW_TO_HIGH
+	ROOF_TYPE_TO_METAL
+}
+
+input AddProjectAssetInput {
+	"""
+	The ID of the project to add the asset to.
+	"""
+	projectId: Int64!
+
+	"""
+	Place ID of the asset to add to the project.
+	"""
+	placeId: String!
+}
+
+"""
+An enumeration of administrative levels for localities. These represent hierarchical
+administrative divisions but do not necessarily correspond to specific political or
+governmental divisions. The same AdministrativeLevel may represent different types of
+divisions in different parts of the world.
+
+Example:
+* In the United States: ADMIN_0 = Country, ADMIN_1 = State, ADMIN_2 = County, METRO = Metropolitan Area
+* In Norway: ADMIN_0 = Country, ADMIN_1 = County (no intermediate level)
+"""
+enum AdministrativeLevel {
+	ADMIN_0
+	ADMIN_1
+	ADMIN_2
+	METRO
+}
 
 """
 Project module status
 """
 enum AggregatedProjectModuleStatus {
-    ACTIVE
-    LOADING
-    LOCKED
-    DIRTY
-    FAILED
+	ACTIVE
+	LOADING
+	LOCKED
+	DIRTY
+	FAILED
 }
 
 """
 Project module section status
 """
 enum AggregatedProjectSectionStatus {
-    ACTIVE
-    DISABLED
-    NODATA
-    DIRTY
-    FAILED
+	ACTIVE
+	DISABLED
+	NODATA
+	DIRTY
+	FAILED
 }
 
 type AssetBuildingMetadata {
-    lat: Float
-    lng: Float
-    countryCode: String
-    rebuildCost: Int64
-    foundationHeight: Int64
-    constructionCombustibilityLevel: ConstructionCombustibilityLevel
-    roofCombustibilityLevel: RoofCombustibilityLevel
-    missileEnvironment: MissileEnvironment
-    windDesignStandard: WindDesignStandard
+	lat: Float
+	lng: Float
+	countryCode: String
+	assetTypeId: AssetTypeId
+	rebuildCost: Int64
+	foundationHeight: Int64
+	constructionCombustibilityLevel: ConstructionCombustibilityLevel
+	roofCombustibilityLevel: RoofCombustibilityLevel
+	missileEnvironment: MissileEnvironment
+	windDesignStandard: WindDesignStandard
+	occupancyType: OccupancyType
+	contentsCost: Int64
+	inventoryCost: Int64
+	placeNOI: Int64
 }
 
 type AssetClimateExposure {
-    flood: AssetClimateExposureFlood
-    wildfire: AssetClimateExposureWildfire
-    heat: AssetClimateExposureHeat
-    cold: AssetClimateExposureCold
-    wind: AssetClimateExposureWind
-    drought: AssetClimateExposureDrought
+	flood: AssetClimateExposureFlood
+	wildfire: AssetClimateExposureWildfire
+	heat: AssetClimateExposureHeat
+	cold: AssetClimateExposureCold
+	wind: AssetClimateExposureWind
+	drought: AssetClimateExposureDrought
+	hazard: AssetClimateExposureHazard
 }
 
 type AssetClimateExposureCold {
-    """
-    The asset's Cold Factor, a numeric integer from 1-10 (where 1 = minimal and 10 = extreme).
-    """
-    coldFactor: Int
+	"""
+	The asset's Cold Factor, a numeric integer from 1-10 (where 1 = minimal and 10 = extreme).
+	"""
+	coldFactor: Int
+		@deprecated(
+			reason: "Replaced by factorScore.score for more granular breakdown by SSP and Year."
+		)
 
-    """
-    Text representation of the Cold Factor. Possible values are: minimal, minor, moderate, major, severe, extreme.
-    """
-    factorScale: FactorScale
+	"""
+	Text representation of the Cold Factor. Possible values are: minimal, minor, moderate, major, severe, extreme.
+	"""
+	factorScale: FactorScale
+		@deprecated(
+			reason: "Replaced by factorScore.scale for more granular breakdown by SSP and Year."
+		)
 
-    """
-    Cold probability details for building.
-    """
-    probability: AssetColdProbability
+	"""
+	Cold factor score and scale by SSP and Year.
+	"""
+	factorScore(
+		"""
+		Filter the array of data based on filterBy, this is a further filtering based on result of projectAssetConnection level filter / sorting.
+		"""
+		filterBy: AssetSortFilter
+	): [FactorScore]
+
+	"""
+	Cold probability details for building.
+	"""
+	probability: AssetColdProbability
 }
 
 type AssetClimateExposureDrought {
-    """
-    The asset's Drought Factor, a numeric integer from 1-10 (where 1 = minimal and 10 = extreme).
-    """
-    droughtFactor: Int
+	"""
+	The asset's Drought Factor, a numeric integer from 1-10 (where 1 = minimal and 10 = extreme).
+	"""
+	droughtFactor: Int
+		@deprecated(
+			reason: "Replaced by factorScore.score for more granular breakdown by SSP and Year."
+		)
 
-    """
-    Text representation of the Drought Factor. Possible values are: minimal, minor, moderate, major, severe, extreme.
-    """
-    factorScale: FactorScale
+	"""
+	Text representation of the Drought Factor. Possible values are: minimal, minor, moderate, major, severe, extreme.
+	"""
+	factorScale: FactorScale
+		@deprecated(
+			reason: "Replaced by factorScore.scale for more granular breakdown by SSP and Year."
+		)
 
-    """
-    Drought probability details for building.
-    """
-    probability: AssetDroughtProbability
+	"""
+	Drought factor score and scale by SSP and Year.
+	"""
+	factorScore(
+		"""
+		Filter the array of data based on filterBy, this is a further filtering based on result of projectAssetConnection level filter / sorting.
+		"""
+		filterBy: AssetSortFilter
+	): [FactorScore]
+
+	"""
+	Drought probability details for building.
+	"""
+	probability: AssetDroughtProbability
 }
 
 type AssetClimateExposureFlood {
-    """
-    The asset's Flood Factor, a numeric integer from 1-10 (where 1 = minimal and 10 = extreme) based on flooding risk to the asset footprint.
-    """
-    floodFactor: Int
+	"""
+	The asset's Flood Factor, a numeric integer from 1-10 (where 1 = minimal and 10 = extreme) based on flooding risk to the asset footprint.
+	"""
+	floodFactor: Int
+		@deprecated(
+			reason: "Replaced by factorScore.score for more granular breakdown by SSP and Year."
+		)
 
-    """
-    Text representation of the Flood Factor. Possible values are: minimal, minor, moderate, major, severe, extreme.
-    """
-    factorScale: FactorScale
+	"""
+	Text representation of the Flood Factor. Possible values are: minimal, minor, moderate, major, severe, extreme.
+	"""
+	factorScale: FactorScale
+		@deprecated(
+			reason: "Replaced by factorScore.scale for more granular breakdown by SSP and Year."
+		)
 
-    """
-    Flood probabilty details for asset.
-    """
-    probability: AssetFloodProbability
+	"""
+	Flood factor score and scale by SSP and Year.
+	"""
+	factorScore(
+		"""
+		Filter the array of data based on filterBy, this is a further filtering based on result of projectAssetConnection level filter / sorting.
+		Will return the full array without it. Ex - passing in filterBy={ssp:SSP_2_45, relativeYear:5, returnPeriod:100} will filter flood exposure array
+		and only keep array items have ssp=SSP_2_45, relativeYear=5, returnPeriod=100
+		"""
+		filterBy: AssetSortFilter
+	): [FactorScore]
 
-    """
-    Details for asset flood losses.
-    """
-    damages: AssetFloodDamages
+	"""
+	Flood probability details for asset.
+	"""
+	probability: AssetFloodProbability
+
+	"""
+	Details for asset flood losses.
+	"""
+	damages: AssetFloodDamages
+}
+
+type AssetClimateExposureHazard {
+	"""
+	Hazard factor score and scale by SSP and Year.
+	"""
+	factorScore(filterBy: AssetSortFilter): [FactorScore]
+
+	"""
+	Details for asset hazard losses.
+	"""
+	damages: AssetHazardDamages
 }
 
 type AssetClimateExposureHeat {
-    """
-    The asset's Heat Factor, a numeric integer from 1-10 (where 1 = minimal and 10 = extreme).
-    """
-    heatFactor: Int
+	"""
+	The asset's Heat Factor, a numeric integer from 1-10 (where 1 = minimal and 10 = extreme).
+	"""
+	heatFactor: Int
+		@deprecated(
+			reason: "Replaced by factorScore.score for more granular breakdown by SSP and Year."
+		)
 
-    """
-    Text representation of the Heat Factor. Possible values are: minimal, minor, moderate, major, severe, extreme.
-    """
-    factorScale: FactorScale
+	"""
+	Text representation of the Heat Factor. Possible values are: minimal, minor, moderate, major, severe, extreme.
+	"""
+	factorScale: FactorScale
+		@deprecated(
+			reason: "Replaced by factorScore.scale for more granular breakdown by SSP and Year."
+		)
 
-    """
-    Heat probability details for asset.
-    """
-    probability: AssetHeatProbability
+	"""
+	Heat factor score and scale by SSP and Year.
+	"""
+	factorScore(
+		"""
+		Filter the array of data based on filterBy, this is a further filtering based on result of projectAssetConnection level filter / sorting.
+		"""
+		filterBy: AssetSortFilter
+	): [FactorScore]
+
+	"""
+	Heat probability details for asset.
+	"""
+	probability: AssetHeatProbability
 }
 
 type AssetClimateExposureWildfire {
-    """
-    The asset's Fire Factor, a numeric integer from 1-10 (where 1 = minimal and 10 = extreme).
-    """
-    fireFactor: Int
+	"""
+	The asset's Fire Factor, a numeric integer from 1-10 (where 1 = minimal and 10 = extreme).
+	"""
+	fireFactor: Int
+		@deprecated(
+			reason: "Replaced by factorScore.score for more granular breakdown by SSP and Year."
+		)
 
-    """
-    Text representation of the Fire Factor. Possible values are: minimal, minor, moderate, major, severe, extreme.
-    """
-    factorScale: FactorScale
+	"""
+	Text representation of the Fire Factor. Possible values are: minimal, minor, moderate, major, severe, extreme.
+	"""
+	factorScale: FactorScale
+		@deprecated(
+			reason: "Replaced by factorScore.scale for more granular breakdown by SSP and Year."
+		)
 
-    """
-    Probability data for the asset.
-    """
-    probability: AssetWildfireProbability
+	"""
+	Fire factor score and scale by SSP and Year.
+	"""
+	factorScore(
+		"""
+		Filter the array of data based on filterBy, this is a further filtering based on result of projectAssetConnection level filter / sorting.
+		"""
+		filterBy: AssetSortFilter
+	): [FactorScore]
 
-    """
-    Details for property fire losses.
-    """
-    damages: AssetWildfireDamages
+	"""
+	Probability data for the asset.
+	"""
+	probability: AssetWildfireProbability
+
+	"""
+	Details for property fire losses.
+	"""
+	damages: AssetWildfireDamages
 }
 
 type AssetClimateExposureWind {
-    """
-    The asset's Wind Factor, a numeric integer from 1-10 (where 1 = minimal and 10 = extreme).
-    """
-    windFactor: Int
+	"""
+	The asset's Wind Factor, a numeric integer from 1-10 (where 1 = minimal and 10 = extreme).
+	"""
+	windFactor: Int
+		@deprecated(
+			reason: "Replaced by factorScore.score for more granular breakdown by SSP and Year."
+		)
 
-    """
-    Text representation of the Wind Factor. Possible values are: minimal, minor, moderate, major, severe, extreme.
-    """
-    factorScale: FactorScale
+	"""
+	Text representation of the Wind Factor. Possible values are: minimal, minor, moderate, major, severe, extreme.
+	"""
+	factorScale: FactorScale
+		@deprecated(
+			reason: "Replaced by factorScore.scale for more granular breakdown by SSP and Year."
+		)
 
-    """
-    Forecast probability.
-    """
-    probability: AssetWindProbability
+	"""
+	Wind factor score and scale by SSP and Year.
+	"""
+	factorScore(
+		"""
+		Filter the array of data based on filterBy, this is a further filtering based on result of projectAssetConnection level filter / sorting.
+		"""
+		filterBy: AssetSortFilter
+	): [FactorScore]
 
-    """
-    Details of damages caused by wind.
-    """
-    damages: AssetWindDamages
+	"""
+	Forecast probability.
+	"""
+	probability: AssetWindProbability
+
+	"""
+	Details of damages caused by wind.
+	"""
+	damages: AssetWindDamages
 }
 
 type AssetColdProbabilitHeatingDays {
-    """
-    Socio-economic pathway of the prediction model.
-    """
-    ssp: SSP!
+	"""
+	Socio-economic pathway of the prediction model.
+	"""
+	ssp: SSP!
 
-    """
-    Year, as relative to the current year.
-    """
-    relativeYear: Int!
+	"""
+	Year, as relative to the current year.
+	"""
+	relativeYear: Int!
 
-    """
-    Heating degree days for a given indoor temp (°F)
-    """
-    heatingDegreeDays: Int
+	"""
+	Heating degree days for a given indoor temp (°F)
+	"""
+	heatingDegreeDays: Int
 }
 
 type AssetColdProbability {
-    coldDays(
-        """
-        Filter the array of data based on filterBy, this is a further filtering based on result of projectAssetConnection level filter / sorting.
-        """
-        filterBy: AssetSortFilter
-    ): [AssetColdProbabilityColdDays!]
-    heatingDays(
-        """
-        Filter the array of data based on filterBy, this is a further filtering based on result of projectAssetConnection level filter / sorting.
-        """
-        filterBy: AssetSortFilter
-    ): [AssetColdProbabilitHeatingDays!]
+	coldDays(
+		"""
+		Filter the array of data based on filterBy, this is a further filtering based on result of projectAssetConnection level filter / sorting.
+		"""
+		filterBy: AssetSortFilter
+	): [AssetColdProbabilityColdDays!]
+	heatingDays(
+		"""
+		Filter the array of data based on filterBy, this is a further filtering based on result of projectAssetConnection level filter / sorting.
+		"""
+		filterBy: AssetSortFilter
+	): [AssetColdProbabilitHeatingDays!]
 }
 
 type AssetColdProbabilityColdDays {
-    """
-    Socio-economic pathway of the prediction model.
-    """
-    ssp: SSP!
+	"""
+	Socio-economic pathway of the prediction model.
+	"""
+	ssp: SSP!
 
-    """
-    Year, as relative to the current year.
-    """
-    relativeYear: Int!
+	"""
+	Year, as relative to the current year.
+	"""
+	relativeYear: Int!
 
-    """
-    Threshold temperature in °F cold index.
-    """
-    threshold: Int!
+	"""
+	Threshold temperature in °F cold index.
+	"""
+	threshold: Int!
 
-    """
-    Days with wind chill index below a threshold (°F)
-    """
-    windchillDays: Int
+	"""
+	Days with wind chill index below a threshold (°F)
+	"""
+	windchillDays: Int
 }
 
 type AssetDroughtProbability {
-    """
-    Return lengths of drought by return period for a given location
-    """
-    duration(
-        """
-        Filter the array of data based on filterBy, this is a further filtering based on result of projectAssetConnection level filter / sorting.
-        """
-        filterBy: AssetSortFilter
-    ): [AssetDroughtProbabilityDuration]
+	"""
+	Return lengths of drought by return period for a given location
+	"""
+	duration(
+		"""
+		Filter the array of data based on filterBy, this is a further filtering based on result of projectAssetConnection level filter / sorting.
+		"""
+		filterBy: AssetSortFilter
+	): [AssetDroughtProbabilityDuration]
 }
 
 type AssetDroughtProbabilityDuration {
-    """
-    Socio-economic pathway of the prediction model.
-    """
-    ssp: SSP!
+	"""
+	Socio-economic pathway of the prediction model.
+	"""
+	ssp: SSP!
 
-    """
-    Return period for the drought probability.
-    """
-    returnPeriod: ReturnPeriod!
+	"""
+	Return period for the drought probability.
+	"""
+	returnPeriod: ReturnPeriod!
 
-    """
-    Year, as relative to the current year.
-    """
-    relativeYear: Int!
+	"""
+	Year, as relative to the current year.
+	"""
+	relativeYear: Int!
 
-    """
-    Weeks of drought at or below SCPDSI (drought level) -2
-    """
-    weeks: Int
+	"""
+	Weeks of drought at or below SCPDSI (drought level) -2
+	"""
+	weeks: Int
 }
 
 """
 Details for asset flood losses.
 """
 type AssetFloodDamages {
-    asset(filterBy: AssetSortFilter): [AssetFloodDamagesAsset!]
-    aal(filterBy: AssetSortFilter): [AssetFloodDamagesAAL!]
+	asset(filterBy: AssetSortFilter): [AssetFloodDamagesAsset!]
+	aal(filterBy: AssetSortFilter): [AssetFloodDamagesAAL!]
 }
 
 """
 Annualized damage cost to the structure in the current year due to flood.
 """
 type AssetFloodDamagesAAL {
-    """
-    Socio-economic pathway of the prediction model.
-    """
-    ssp: SSP!
+	"""
+	Socio-economic pathway of the prediction model.
+	"""
+	ssp: SSP!
 
-    """
-    Year, as relative to the current year.
-    """
-    relativeYear: Int!
+	"""
+	Year, as relative to the current year.
+	"""
+	relativeYear: Int!
 
-    """
-    Percentile value for estimates, one of: 10, 50, 90. 10th percentile estimate is low value, 90th percentile is high value, and 50th is mean.
-    """
-    percentile: Int!
+	"""
+	Percentile value for estimates, one of: 10, 50, 90. 10th percentile estimate is low value, 90th percentile is high value, and 50th is mean.
+	"""
+	percentile: Int!
 
-    """
-    Annualized damage cost to the structure in the current year due to flood.
-    """
-    aal: Int64
+	"""
+	Annualized damage cost to the structure in the current year due to flood.
+	"""
+	aal: Float
+
+	"""
+	Average annual downtime in days.
+	"""
+	repairDays: Int
+
+	"""
+	Average annual downtime in forgone revenue. Assumes that every day of the year has the same revenue (1/365.25 share of the annual revenue)
+	"""
+	interruptionLoss: Int64
+
+	"""
+	Sum of AAL and average annual interruption loss.
+	"""
+	cashLoss: Int64
+
+	"""
+	Annualized cost from lost inventory, lost contents, and business interruption in the given modeled event. NULL if contents or inventory curve is unavailable for given asset type, or if NOI (revenue) is missing.
+	"""
+	operatorLoss: Int64
+
+	"""
+	Cumulative annualized cost from lost inventory, lost contents, and business interruption in the given modeled event. NULL if contents or inventory curve is unavailable for given asset type, or if NOI (revenue) is missing.
+	"""
+	operatorLossCumulative: Int64
 }
 
 type AssetFloodDamagesAsset {
-    """
-    Socio-economic pathway of the prediction model.
-    """
-    ssp: SSP!
+	"""
+	Socio-economic pathway of the prediction model.
+	"""
+	ssp: SSP!
 
-    """
-    Year, as relative to the current year.
-    """
-    relativeYear: Int!
+	"""
+	Year, as relative to the current year.
+	"""
+	relativeYear: Int!
 
-    """
-    Return period of flooding.
-    """
-    returnPeriod: ReturnPeriod!
+	"""
+	Return period of flooding.
+	"""
+	returnPeriod: ReturnPeriod!
 
-    """
-    Percentile value for estimates, one of: 10, 50, 90. 10th percentile estimate is low value, 90th percentile is high value, and 50th is mean.
-    """
-    percentile: Int!
+	"""
+	Percentile value for estimates, one of: 10, 50, 90. 10th percentile estimate is low value, 90th percentile is high value, and 50th is mean.
+	"""
+	percentile: Int!
 
-    """
-    Estimated number of days to rebuild or repair damage due to flood.
-    """
-    repairDays: Int
+	"""
+	Estimated number of days to rebuild or repair damage due to flood.
+	"""
+	repairDays: Int
 
-    """
-    Estimated cost to repair damage due to flood.
-    """
-    repairCost: Int64
+	"""
+	Estimated cost to repair damage due to flood.
+	"""
+	repairCost: Int64
+
+	"""
+	Estimated downtime loss of revenue due to flood.
+	"""
+	interruptionLoss: Int64
+
+	"""
+	Sum of repair cost, interruption loss and losses to contents and inventory due to flood.
+	"""
+	cashLoss: Int64
+
+	"""
+	Cost from lost inventory, lost contents, and business interruption in the given modeled event. NULL if contents or inventory curve is unavailable for given asset type, or if NOI (revenue) is missing.
+	"""
+	operatorLoss: Int64
 }
 
 """
 Flood probability details for asset.
 """
 type AssetFloodProbability {
-    """
-    Delivers the flood depth (in centimeters) for flooding to the asset footprint broken down by return period and year of annual risk.
-    The low, mid, high likelihood is returned within the associated threshold and year. Available depth thresholds include >0cm, >15cm, and >30cm, and are broken down by the following years within the model - 2020, 2025, 2030, 2035, 2040, 2045, and 2050.
-    """
-    depth(
-        """
-        Filter the array of data based on filterBy, this is a further filtering based on result of projectAssetConnection level filter / sorting.
-        Will return the full array without it. Ex - passing in filterBy={ssp:SSP_2_45, relativeYear:5, returnPeriod:100} will filter flood exposure array
-        and only keep array items have ssp=SSP_2_45, relativeYear=5, returnPeriod=100
-        """
-        filterBy: AssetSortFilter
-    ): [AssetFloodProbabilityDepth]
+	"""
+	Delivers the flood depth (in centimeters) for flooding to the asset footprint broken down by return period and year of annual risk.
+	The low, mid, high likelihood is returned within the associated threshold and year. Available depth thresholds include >0cm, >15cm, and >30cm, and are broken down by the following years within the model - 2020, 2025, 2030, 2035, 2040, 2045, and 2050.
+	"""
+	depth(
+		"""
+		Filter the array of data based on filterBy, this is a further filtering based on result of projectAssetConnection level filter / sorting.
+		Will return the full array without it. Ex - passing in filterBy={ssp:SSP_2_45, relativeYear:5, returnPeriod:100} will filter flood exposure array
+		and only keep array items have ssp=SSP_2_45, relativeYear=5, returnPeriod=100
+		"""
+		filterBy: AssetSortFilter
+	): [AssetFloodProbabilityDepth]
 
-    """
-    The risk likelihood (% probability) for flooding to the asset footprint.
-    """
-    cumulative(
-        """
-        Filter the array of data based on filterBy, this is a further filtering based on result of projectAssetConnection level filter / sorting.
-        Will return the full array without it. Ex - passing in filterBy={ssp:SSP_2_45, relativeYear:5, returnPeriod:100} will filter flood exposure array
-        and only keep array items have ssp=SSP_2_45, relativeYear=5, returnPeriod=100
-        """
-        filterBy: AssetSortFilter
-    ): [AssetFloodProbabilityCumulative]
+	"""
+	The risk likelihood (% probability) for flooding to the asset footprint.
+	"""
+	cumulative(
+		"""
+		Filter the array of data based on filterBy, this is a further filtering based on result of projectAssetConnection level filter / sorting.
+		Will return the full array without it. Ex - passing in filterBy={ssp:SSP_2_45, relativeYear:5, returnPeriod:100} will filter flood exposure array
+		and only keep array items have ssp=SSP_2_45, relativeYear=5, returnPeriod=100
+		"""
+		filterBy: AssetSortFilter
+	): [AssetFloodProbabilityCumulative]
 }
 
 type AssetFloodProbabilityCumulative {
-    """
-    Socio-economic pathway of the prediction model.
-    """
-    ssp: SSP!
+	"""
+	Socio-economic pathway of the prediction model.
+	"""
+	ssp: SSP!
 
-    """
-    Year, as relative to the current year.
-    """
-    relativeYear: Int!
+	"""
+	Year, as relative to the current year.
+	"""
+	relativeYear: Int!
 
-    """
-    Threshold to calculate cumulative probability of flooding in feet.
-    """
-    depth: Float
+	"""
+	Threshold to calculate cumulative probability of flooding in feet.
+	"""
+	depth: Float
 
-    """
-    Cumulative probability of floods of reaching the given mean depth at the asset.
-    """
-    mean: Float
+	"""
+	Cumulative probability of floods of reaching the given mean depth at the asset.
+	"""
+	mean: Float
 
-    """
-    Cumulative probability of floods of a given depth reaching the asset.
-    """
-    lowPoint: Float
+	"""
+	Cumulative probability of floods of a given depth reaching the asset.
+	"""
+	lowPoint: Float
 }
 
 """
 The flood depth (in centimeters) for flooding to the asset footprint broken down by return period and year of annual risk.
 """
 type AssetFloodProbabilityDepth {
-    """
-    Socio-economic pathway of the prediction model.
-    """
-    ssp: SSP!
+	"""
+	Socio-economic pathway of the prediction model.
+	"""
+	ssp: SSP!
 
-    """
-    Return period of flooding.
-    """
-    returnPeriod: ReturnPeriod!
+	"""
+	Return period of flooding.
+	"""
+	returnPeriod: ReturnPeriod!
 
-    """
-    Year, as relative to the current year.
-    """
-    relativeYear: Int!
+	"""
+	Year, as relative to the current year.
+	"""
+	relativeYear: Int!
 
-    """
-    Flood depth at the selected point or the mean depth along asset outline if there's a asset outline (in feet).
-    """
-    mean: Float
+	"""
+	Flood depth at the selected point or the mean depth along asset outline if there's a asset outline (in feet).
+	"""
+	mean: Float
 
-    """
-    Flood depth at the low point along a asset outline. Same as depth if there's no asset outline (in feet).
-    """
-    lowPoint: Float
+	"""
+	Flood depth at the low point along a asset outline. Same as depth if there's no asset outline (in feet).
+	"""
+	lowPoint: Float
+}
+
+"""
+Details for asset hazard losses.
+"""
+type AssetHazardDamages {
+	aal(filterBy: AssetSortFilter): [AssetHazardDamagesAAL!]
+}
+
+"""
+Annualized damage cost to the structure in the current year due to all hazards.
+"""
+type AssetHazardDamagesAAL {
+	"""
+	Socio-economic pathway of the prediction model.
+	"""
+	ssp: SSP!
+
+	"""
+	Year, as relative to the current year.
+	"""
+	relativeYear: Int!
+
+	"""
+	Percentile value for estimates, one of: 10, 50, 90. 10th percentile estimate is low value, 90th percentile is high value, and 50th is mean.
+	"""
+	percentile: Int!
+
+	"""
+	Annualized damage cost to the structure in the current year due to all hazards.
+	"""
+	aal: Float
+
+	"""
+	Average annual downtime in days.
+	"""
+	repairDays: Int
+
+	"""
+	Average annual downtime in forgone revenue. Assumes that every day of the year has the same revenue (1/365.25 share of the annual revenue)
+	"""
+	interruptionLoss: Int64
+
+	"""
+	Sum of AAL and average annual interruption loss.
+	"""
+	cashLoss: Int64
+
+	"""
+	Annualized cost from lost inventory, lost contents, and business interruption in the given modeled event. NULL if contents or inventory curve is unavailable for given asset type, or if NOI (revenue) is missing.
+	"""
+	operatorLoss: Int64
+
+	"""
+	Cumulative annualized cost from lost inventory, lost contents, and business interruption in the given modeled event. NULL if contents or inventory curve is unavailable for given asset type, or if NOI (revenue) is missing.
+	"""
+	operatorLossCumulative: Int64
 }
 
 type AssetHeatProbability {
-    heatDays(
-        """
-        Filter the array of data based on filterBy, this is a further filtering based on result of projectAssetConnection level filter / sorting.
-        """
-        filterBy: AssetSortFilter
-    ): [AssetHeatProbabilityHeatDays]
-    coolingDays(
-        """
-        Filter the array of data based on filterBy, this is a further filtering based on result of projectAssetConnection level filter / sorting.
-        """
-        filterBy: AssetSortFilter
-    ): [AssetHeatProbabilityCoolingDays]
+	heatDays(
+		"""
+		Filter the array of data based on filterBy, this is a further filtering based on result of projectAssetConnection level filter / sorting.
+		"""
+		filterBy: AssetSortFilter
+	): [AssetHeatProbabilityHeatDays]
+	coolingDays(
+		"""
+		Filter the array of data based on filterBy, this is a further filtering based on result of projectAssetConnection level filter / sorting.
+		"""
+		filterBy: AssetSortFilter
+	): [AssetHeatProbabilityCoolingDays]
 }
 
 type AssetHeatProbabilityCoolingDays {
-    """
-    Socio-economic pathway of the prediction model.
-    """
-    ssp: SSP!
+	"""
+	Socio-economic pathway of the prediction model.
+	"""
+	ssp: SSP!
 
-    """
-    Year, as relative to the current year.
-    """
-    relativeYear: Int!
+	"""
+	Year, as relative to the current year.
+	"""
+	relativeYear: Int!
 
-    """
-    Cooling degree days for a given indoor temp (°F)
-    """
-    coolingDegreeDays: Float
+	"""
+	Cooling degree days for a given indoor temp (°F)
+	"""
+	coolingDegreeDays: Float
 }
 
 type AssetHeatProbabilityHeatDays {
-    """
-    Socio-economic pathway of the prediction model.
-    """
-    ssp: SSP!
+	"""
+	Socio-economic pathway of the prediction model.
+	"""
+	ssp: SSP!
 
-    """
-    Year, as relative to the current year.
-    """
-    relativeYear: Int!
+	"""
+	Year, as relative to the current year.
+	"""
+	relativeYear: Int!
 
-    """
-    Threshold temperature in °F heat index.
-    """
-    threshold: Int!
+	"""
+	Threshold temperature in °F heat index.
+	"""
+	threshold: Int!
 
-    """
-    Days with high heat index at or above a threshold (°F).
-    """
-    heatIndexDays: Int
+	"""
+	Days with high heat index at or above a threshold (°F).
+	"""
+	heatIndexDays: Int
+}
+
+type AssetLocality {
+	"""
+	Locality data for the asset's country.
+	"""
+	admin0: Locality
+
+	"""
+	Locality data for the asset's state (or equivalent).
+	"""
+	admin1: Locality
+
+	"""
+	Locality data for the asset's county (or equivalent).
+	"""
+	admin2: Locality
+
+	"""
+	Locality data for the asset's metro (or equivalent).
+	"""
+	metro: Locality
 }
 
 type AssetScenarioAnalysis {
-    """
-    Asset effects for the Scenario Analysis module.
-    """
-    assetEffects: [AssetScenarioAnalysisEffects]
+	"""
+	Asset effects for the Scenario Analysis module.
+	"""
+	assetEffects: [AssetScenarioAnalysisEffects]
 }
 
 type AssetScenarioAnalysisEffects {
-    """
-    Peril the data appies to. 2 = inland flood, 3 = hurricane, 4 = wildfire, 5 = overall.
-    """
-    perilId: Int
+	"""
+	Peril the data appies to. 2 = inland flood, 3 = hurricane, 4 = wildfire, 5 = overall.
+	"""
+	perilId: Int
 
-    """
-    Relative year for the data.
-    """
-    relativeYear: Int
+	"""
+	Relative year for the data.
+	"""
+	relativeYear: Int
 
-    """
-    Socio-economic pathway of the prediction model.
-    """
-    ssp: SSP
+	"""
+	Socio-economic pathway of the prediction model.
+	"""
+	ssp: SSP
 
-    """
-    Return period of calculation.
-    """
-    returnPeriod: ReturnPeriod
+	"""
+	Return period of calculation.
+	"""
+	returnPeriod: ReturnPeriod
 
-    """
-    Average damage without insurance
-    """
-    damageGross: Int64
+	"""
+	Average damage without insurance
+	"""
+	damageGross: Int64
 
-    """
-    Average damage without insurance as a percentage of asset value
-    """
-    damageGrossPercent: Float
+	"""
+	Average damage without insurance as a percentage of asset value
+	"""
+	damageGrossPercent: Float
 
-    """
-    Average damage with insurance
-    """
-    damageNet: Int64
+	"""
+	Average damage with insurance
+	"""
+	damageNet: Int64
 
-    """
-    Average damage with insurance as a percentage of asset value
-    """
-    damageNetPercent: Float
+	"""
+	Average damage with insurance as a percentage of asset value
+	"""
+	damageNetPercent: Float
 
-    """
-    Percent of synthetic years where asset is damaged
-    """
-    yearsDamagedPercent: Float
+	"""
+	Percent of synthetic years where asset is damaged
+	"""
+	yearsDamagedPercent: Float
 
-    """
-    Average gross business interruption loss
-    """
-    businessInterruptionGross: Int64
+	"""
+	Average gross business interruption loss
+	"""
+	businessInterruptionGross: Int64
 
-    """
-    Average gross business interruption loss as a percentage of asset value
-    """
-    businessInterruptionGrossPercent: Float
+	"""
+	Average gross business interruption loss as a percentage of asset value
+	"""
+	businessInterruptionGrossPercent: Float
 
-    """
-    Average net business interruption loss
-    """
-    businessInterruptionNet: Int64
+	"""
+	Average net business interruption loss
+	"""
+	businessInterruptionNet: Int64
 
-    """
-    Average net business interruption loss as a percentage of asset value
-    """
-    businessInterruptionNetPercent: Float
+	"""
+	Average net business interruption loss as a percentage of asset value
+	"""
+	businessInterruptionNetPercent: Float
 
-    """
-    Average cash gross loss
-    """
-    cashGross: Int64
+	"""
+	Average cash gross loss
+	"""
+	cashGross: Int64
 
-    """
-    Average cash gross loss
-    """
-    cashGrossPercent: Float
+	"""
+	Average cash gross loss
+	"""
+	cashGrossPercent: Float
 
-    """
-    Average cash net loss
-    """
-    cashNet: Int64
+	"""
+	Average cash net loss
+	"""
+	cashNet: Int64
 
-    """
-    Average cash net loss as a percentage of asset value
-    """
-    cashNetPercent: Float
+	"""
+	Average cash net loss as a percentage of asset value
+	"""
+	cashNetPercent: Float
 }
 
 """
 Sort order for the asset connection.
 """
 enum AssetSort {
-    DEFAULT
-    CUSTOM_ID_ASC
-    CUSTOM_ID_DESC
-    CLIMATE_EXPOSURE_FLOOD_FACTOR_ASC
-    CLIMATE_EXPOSURE_FLOOD_FACTOR_DESC
-    CLIMATE_EXPOSURE_FIRE_FACTOR_ASC
-    CLIMATE_EXPOSURE_FIRE_FACTOR_DESC
-    CLIMATE_EXPOSURE_WIND_FACTOR_ASC
-    CLIMATE_EXPOSURE_WIND_FACTOR_DESC
-    CLIMATE_EXPOSURE_HEAT_FACTOR_ASC
-    CLIMATE_EXPOSURE_HEAT_FACTOR_DESC
-    CLIMATE_EXPOSURE_COLD_FACTOR_ASC
-    CLIMATE_EXPOSURE_COLD_FACTOR_DESC
-    CLIMATE_EXPOSURE_DROUGHT_FACTOR_ASC
-    CLIMATE_EXPOSURE_DROUGHT_FACTOR_DESC
-    CLIMATE_EXPOSURE_FLOOD_DEPTH_MEAN_ASC
-    CLIMATE_EXPOSURE_FLOOD_DEPTH_MEAN_DESC
-    CLIMATE_EXPOSURE_FLOOD_DAMAGE_AAL_ASC
-    CLIMATE_EXPOSURE_FLOOD_DAMAGE_AAL_DESC
-    CLIMATE_EXPOSURE_FLOOD_REPAIR_DAYS_ASC
-    CLIMATE_EXPOSURE_FLOOD_REPAIR_DAYS_DESC
-    CLIMATE_EXPOSURE_FLOOD_REPAIR_COST_ASC
-    CLIMATE_EXPOSURE_FLOOD_REPAIR_COST_DESC
-    CLIMATE_EXPOSURE_WIND_SPEED3SEC_ASC
-    CLIMATE_EXPOSURE_WIND_SPEED3SEC_DESC
-    CLIMATE_EXPOSURE_WIND_DAMAGE_AAL_ASC
-    CLIMATE_EXPOSURE_WIND_DAMAGE_AAL_DESC
-    CLIMATE_EXPOSURE_WIND_REPAIR_DAYS_ASC
-    CLIMATE_EXPOSURE_WIND_REPAIR_DAYS_DESC
-    CLIMATE_EXPOSURE_WIND_REPAIR_COST_ASC
-    CLIMATE_EXPOSURE_WIND_REPAIR_COST_DESC
-    CLIMATE_EXPOSURE_FIRE_BURN_PROB_ASC
-    CLIMATE_EXPOSURE_FIRE_BURN_PROB_DESC
-    CLIMATE_EXPOSURE_FIRE_CUMU_PROB_ASC
-    CLIMATE_EXPOSURE_FIRE_CUMU_PROB_DESC
-    CLIMATE_EXPOSURE_FIRE_DAMAGE_AAL_ASC
-    CLIMATE_EXPOSURE_FIRE_DAMAGE_AAL_DESC
-    CLIMATE_EXPOSURE_FIRE_DESTRUCTION_PROB_ASC
-    CLIMATE_EXPOSURE_FIRE_DESTRUCTION_PROB_DESC
-    CLIMATE_EXPOSURE_FIRE_CUMU_DESTRUCTION_PROB_ASC
-    CLIMATE_EXPOSURE_FIRE_CUMU_DESTRUCTION_PROB_DESC
-    CLIMATE_EXPOSURE_FIRE_REPAIR_DAYS_ASC
-    CLIMATE_EXPOSURE_FIRE_REPAIR_DAYS_DESC
-    CLIMATE_EXPOSURE_HEAT_HEATING_INDEX_DAYS_ASC
-    CLIMATE_EXPOSURE_HEAT_HEATING_INDEX_DAYS_DESC
-    CLIMATE_EXPOSURE_HEAT_COOLING_DEGREE_DAYS_ASC
-    CLIMATE_EXPOSURE_HEAT_COOLING_DEGREE_DAYS_DESC
-    CLIMATE_EXPOSURE_COLD_WIND_CHILL_DAYS_ASC
-    CLIMATE_EXPOSURE_COLD_WIND_CHILL_DAYS_DESC
-    CLIMATE_EXPOSURE_COLD_HEATING_DEGREE_DAYS_ASC
-    CLIMATE_EXPOSURE_COLD_HEATING_DEGREE_DAYS_DESC
-    CLIMATE_EXPOSURE_DROUGHT_DURATION_WEEKS_ASC
-    CLIMATE_EXPOSURE_DROUGHT_DURATION_WEEKS_DESC
+	DEFAULT
+	CUSTOM_ID_ASC
+	CUSTOM_ID_DESC
+	CLIMATE_EXPOSURE_FLOOD_FACTOR_ASC
+		@deprecated(
+			reason: "Use CLIMATE_EXPOSURE_FLOOD_FACTOR_SCORE_ASC with the more granular flood.factorScore.score instead"
+		)
+	CLIMATE_EXPOSURE_FLOOD_FACTOR_DESC
+		@deprecated(
+			reason: "Use CLIMATE_EXPOSURE_FLOOD_FACTOR_SCORE_DESC with the more granular flood.factorScore.score instead"
+		)
+	CLIMATE_EXPOSURE_FIRE_FACTOR_ASC
+		@deprecated(
+			reason: "Use CLIMATE_EXPOSURE_FIRE_FACTOR_SCORE_ASC with the more granular wildfire.factorScore.score instead"
+		)
+	CLIMATE_EXPOSURE_FIRE_FACTOR_DESC
+		@deprecated(
+			reason: "Use CLIMATE_EXPOSURE_FIRE_FACTOR_SCORE_DESC with the more granular wildfire.factorScore.score instead"
+		)
+	CLIMATE_EXPOSURE_WIND_FACTOR_ASC
+		@deprecated(
+			reason: "Use CLIMATE_EXPOSURE_WIND_FACTOR_SCORE_ASC with the more granular wind.factorScore.score instead"
+		)
+	CLIMATE_EXPOSURE_WIND_FACTOR_DESC
+		@deprecated(
+			reason: "Use CLIMATE_EXPOSURE_WIND_FACTOR_SCORE_DESC with the more granular wind.factorScore.score instead"
+		)
+	CLIMATE_EXPOSURE_HEAT_FACTOR_ASC
+		@deprecated(
+			reason: "Use CLIMATE_EXPOSURE_HEAT_FACTOR_SCORE_ASC with the more granular heat.factorScore.score instead"
+		)
+	CLIMATE_EXPOSURE_HEAT_FACTOR_DESC
+		@deprecated(
+			reason: "Use CLIMATE_EXPOSURE_HEAT_FACTOR_SCORE_DESC with the more granular heat.factorScore.score instead"
+		)
+	CLIMATE_EXPOSURE_COLD_FACTOR_ASC
+		@deprecated(
+			reason: "Use CLIMATE_EXPOSURE_COLD_FACTOR_SCORE_ASC with the more granular cold.factorScore.score instead"
+		)
+	CLIMATE_EXPOSURE_COLD_FACTOR_DESC
+		@deprecated(
+			reason: "Use CLIMATE_EXPOSURE_COLD_FACTOR_SCORE_DESC with the more granular cold.factorScore.score instead"
+		)
+	CLIMATE_EXPOSURE_DROUGHT_FACTOR_ASC
+		@deprecated(
+			reason: "Use CLIMATE_EXPOSURE_DROUGHT_FACTOR_SCORE_ASC with the more granular drought.factorScore.score instead"
+		)
+	CLIMATE_EXPOSURE_DROUGHT_FACTOR_DESC
+		@deprecated(
+			reason: "Use CLIMATE_EXPOSURE_DROUGHT_FACTOR_SCORE_DESC with the more granular drought.factorScore.score instead"
+		)
+	CLIMATE_EXPOSURE_FLOOD_DEPTH_MEAN_ASC
+	CLIMATE_EXPOSURE_FLOOD_DEPTH_MEAN_DESC
+	CLIMATE_EXPOSURE_FLOOD_REPAIR_DAYS_ASC
+	CLIMATE_EXPOSURE_FLOOD_REPAIR_DAYS_DESC
+	CLIMATE_EXPOSURE_FLOOD_REPAIR_COST_ASC
+	CLIMATE_EXPOSURE_FLOOD_REPAIR_COST_DESC
+	CLIMATE_EXPOSURE_FLOOD_INTERRUPTION_LOSS_ASC
+	CLIMATE_EXPOSURE_FLOOD_INTERRUPTION_LOSS_DESC
+	CLIMATE_EXPOSURE_FLOOD_CASH_LOSS_ASC
+	CLIMATE_EXPOSURE_FLOOD_CASH_LOSS_DESC
+	CLIMATE_EXPOSURE_FLOOD_FACTOR_SCORE_ASC
+	CLIMATE_EXPOSURE_FLOOD_FACTOR_SCORE_DESC
+	CLIMATE_EXPOSURE_FLOOD_LOW_POINT_ASC
+	CLIMATE_EXPOSURE_FLOOD_LOW_POINT_DESC
+	CLIMATE_EXPOSURE_FLOOD_DAMAGE_AAL_ASC
+	CLIMATE_EXPOSURE_FLOOD_DAMAGE_AAL_DESC
+	CLIMATE_EXPOSURE_FLOOD_DAMAGE_AAL_REPAIR_DAYS_ASC
+	CLIMATE_EXPOSURE_FLOOD_DAMAGE_AAL_REPAIR_DAYS_DESC
+	CLIMATE_EXPOSURE_FLOOD_DAMAGE_AAL_INTERRUPTION_ASC
+	CLIMATE_EXPOSURE_FLOOD_DAMAGE_AAL_INTERRUPTION_DESC
+	CLIMATE_EXPOSURE_FLOOD_DAMAGE_AAL_CASH_LOSS_ASC
+	CLIMATE_EXPOSURE_FLOOD_DAMAGE_AAL_CASH_LOSS_DESC
+	CLIMATE_EXPOSURE_WIND_SPEED3SEC_ASC
+	CLIMATE_EXPOSURE_WIND_SPEED3SEC_DESC
+	CLIMATE_EXPOSURE_WIND_REPAIR_DAYS_ASC
+	CLIMATE_EXPOSURE_WIND_REPAIR_DAYS_DESC
+	CLIMATE_EXPOSURE_WIND_REPAIR_COST_ASC
+	CLIMATE_EXPOSURE_WIND_REPAIR_COST_DESC
+	CLIMATE_EXPOSURE_WIND_INTERRUPTION_LOSS_ASC
+	CLIMATE_EXPOSURE_WIND_INTERRUPTION_LOSS_DESC
+	CLIMATE_EXPOSURE_WIND_CASH_LOSS_ASC
+	CLIMATE_EXPOSURE_WIND_CASH_LOSS_DESC
+	CLIMATE_EXPOSURE_WIND_FACTOR_SCORE_ASC
+	CLIMATE_EXPOSURE_WIND_FACTOR_SCORE_DESC
+	CLIMATE_EXPOSURE_WIND_DAMAGE_AAL_ASC
+	CLIMATE_EXPOSURE_WIND_DAMAGE_AAL_DESC
+	CLIMATE_EXPOSURE_WIND_DAMAGE_AAL_REPAIR_DAYS_ASC
+	CLIMATE_EXPOSURE_WIND_DAMAGE_AAL_REPAIR_DAYS_DESC
+	CLIMATE_EXPOSURE_WIND_DAMAGE_AAL_INTERRUPTION_ASC
+	CLIMATE_EXPOSURE_WIND_DAMAGE_AAL_INTERRUPTION_DESC
+	CLIMATE_EXPOSURE_WIND_DAMAGE_AAL_CASH_LOSS_ASC
+	CLIMATE_EXPOSURE_WIND_DAMAGE_AAL_CASH_LOSS_DESC
+	CLIMATE_EXPOSURE_FIRE_BURN_PROB_ASC
+	CLIMATE_EXPOSURE_FIRE_BURN_PROB_DESC
+	CLIMATE_EXPOSURE_FIRE_CUMU_PROB_ASC
+	CLIMATE_EXPOSURE_FIRE_CUMU_PROB_DESC
+	CLIMATE_EXPOSURE_FIRE_DESTRUCTION_PROB_ASC
+	CLIMATE_EXPOSURE_FIRE_DESTRUCTION_PROB_DESC
+	CLIMATE_EXPOSURE_FIRE_CUMU_DESTRUCTION_PROB_ASC
+	CLIMATE_EXPOSURE_FIRE_CUMU_DESTRUCTION_PROB_DESC
+	CLIMATE_EXPOSURE_FIRE_REPAIR_DAYS_ASC
+	CLIMATE_EXPOSURE_FIRE_REPAIR_DAYS_DESC
+	CLIMATE_EXPOSURE_FIRE_INTERRUPTION_LOSS_ASC
+	CLIMATE_EXPOSURE_FIRE_INTERRUPTION_LOSS_DESC
+	CLIMATE_EXPOSURE_FIRE_CASH_LOSS_ASC
+	CLIMATE_EXPOSURE_FIRE_CASH_LOSS_DESC
+	CLIMATE_EXPOSURE_FIRE_FACTOR_SCORE_ASC
+	CLIMATE_EXPOSURE_FIRE_FACTOR_SCORE_DESC
+	CLIMATE_EXPOSURE_FIRE_DAMAGE_AAL_ASC
+	CLIMATE_EXPOSURE_FIRE_DAMAGE_AAL_DESC
+	CLIMATE_EXPOSURE_FIRE_DAMAGE_AAL_REPAIR_DAYS_ASC
+	CLIMATE_EXPOSURE_FIRE_DAMAGE_AAL_REPAIR_DAYS_DESC
+	CLIMATE_EXPOSURE_FIRE_DAMAGE_AAL_INTERRUPTION_ASC
+	CLIMATE_EXPOSURE_FIRE_DAMAGE_AAL_INTERRUPTION_DESC
+	CLIMATE_EXPOSURE_FIRE_DAMAGE_AAL_CASH_LOSS_ASC
+	CLIMATE_EXPOSURE_FIRE_DAMAGE_AAL_CASH_LOSS_DESC
+	CLIMATE_EXPOSURE_HAZARD_DAMAGE_AAL_ASC
+	CLIMATE_EXPOSURE_HAZARD_DAMAGE_AAL_DESC
+	CLIMATE_EXPOSURE_HAZARD_DAMAGE_AAL_REPAIR_DAYS_ASC
+	CLIMATE_EXPOSURE_HAZARD_DAMAGE_AAL_REPAIR_DAYS_DESC
+	CLIMATE_EXPOSURE_HAZARD_DAMAGE_AAL_INTERRUPTION_ASC
+	CLIMATE_EXPOSURE_HAZARD_DAMAGE_AAL_INTERRUPTION_DESC
+	CLIMATE_EXPOSURE_HAZARD_DAMAGE_AAL_CASH_LOSS_ASC
+	CLIMATE_EXPOSURE_HAZARD_DAMAGE_AAL_CASH_LOSS_DESC
+	CLIMATE_EXPOSURE_HEAT_HEATING_INDEX_DAYS_ASC
+	CLIMATE_EXPOSURE_HEAT_HEATING_INDEX_DAYS_DESC
+	CLIMATE_EXPOSURE_HEAT_COOLING_DEGREE_DAYS_ASC
+	CLIMATE_EXPOSURE_HEAT_COOLING_DEGREE_DAYS_DESC
+	CLIMATE_EXPOSURE_HEAT_FACTOR_SCORE_ASC
+	CLIMATE_EXPOSURE_HEAT_FACTOR_SCORE_DESC
+	CLIMATE_EXPOSURE_COLD_WIND_CHILL_DAYS_ASC
+	CLIMATE_EXPOSURE_COLD_WIND_CHILL_DAYS_DESC
+	CLIMATE_EXPOSURE_COLD_HEATING_DEGREE_DAYS_ASC
+	CLIMATE_EXPOSURE_COLD_HEATING_DEGREE_DAYS_DESC
+	CLIMATE_EXPOSURE_COLD_FACTOR_SCORE_ASC
+	CLIMATE_EXPOSURE_COLD_FACTOR_SCORE_DESC
+	CLIMATE_EXPOSURE_DROUGHT_DURATION_WEEKS_ASC
+	CLIMATE_EXPOSURE_DROUGHT_DURATION_WEEKS_DESC
+	CLIMATE_EXPOSURE_DROUGHT_FACTOR_SCORE_ASC
+	CLIMATE_EXPOSURE_DROUGHT_FACTOR_SCORE_DESC
+	CLIMATE_EXPOSURE_HAIL_FACTOR_SCORE_ASC
+	CLIMATE_EXPOSURE_HAIL_FACTOR_SCORE_DESC
+	CLIMATE_EXPOSURE_AIR_FACTOR_SCORE_ASC
+	CLIMATE_EXPOSURE_AIR_FACTOR_SCORE_DESC
+	CLIMATE_EXPOSURE_HAZARD_FACTOR_SCORE_ASC
+	CLIMATE_EXPOSURE_HAZARD_FACTOR_SCORE_DESC
+	ADMIN_0_MACROECONOMIC_ECON_FACTOR_CLIMATE_ASC
+	ADMIN_0_MACROECONOMIC_ECON_FACTOR_CLIMATE_DESC
+	ADMIN_0_MACROECONOMIC_ECON_FACTOR_CLIMATE_MARKET_ASC
+	ADMIN_0_MACROECONOMIC_ECON_FACTOR_CLIMATE_MARKET_DESC
+	ADMIN_0_MACROECONOMIC_POPULATION_ASC
+	ADMIN_0_MACROECONOMIC_POPULATION_DESC
+	ADMIN_0_MACROECONOMIC_POPULATION_CHANGE_FACTOR_CLIMATE_ASC
+	ADMIN_0_MACROECONOMIC_POPULATION_CHANGE_FACTOR_CLIMATE_DESC
+	ADMIN_0_MACROECONOMIC_POPULATION_CHANGE_FACTOR_CLIMATE_MARKET_ASC
+	ADMIN_0_MACROECONOMIC_POPULATION_CHANGE_FACTOR_CLIMATE_MARKET_DESC
+	ADMIN_0_MACROECONOMIC_GDP_ASC
+	ADMIN_0_MACROECONOMIC_GDP_DESC
+	ADMIN_0_MACROECONOMIC_GDP_CHANGE_FACTOR_CLIMATE_ASC
+	ADMIN_0_MACROECONOMIC_GDP_CHANGE_FACTOR_CLIMATE_DESC
+	ADMIN_0_MACROECONOMIC_GDP_CHANGE_FACTOR_CLIMATE_MARKET_ASC
+	ADMIN_0_MACROECONOMIC_GDP_CHANGE_FACTOR_CLIMATE_MARKET_DESC
+	ADMIN_0_MACROECONOMIC_GDPPC_ASC
+	ADMIN_0_MACROECONOMIC_GDPPC_DESC
+	ADMIN_0_MACROECONOMIC_GDPPC_CHANGE_FACTOR_CLIMATE_ASC
+	ADMIN_0_MACROECONOMIC_GDPPC_CHANGE_FACTOR_CLIMATE_DESC
+	ADMIN_0_MACROECONOMIC_GDPPC_CHANGE_FACTOR_CLIMATE_MARKET_ASC
+	ADMIN_0_MACROECONOMIC_GDPPC_CHANGE_FACTOR_CLIMATE_MARKET_DESC
+	ADMIN_0_MACROECONOMIC_AVERAGE_GROSS_INCOME_ASC
+	ADMIN_0_MACROECONOMIC_AVERAGE_GROSS_INCOME_DESC
+	ADMIN_0_MACROECONOMIC_AVERAGE_GROSS_INCOME_CHANGE_FACTOR_CLIMATE_ASC
+	ADMIN_0_MACROECONOMIC_AVERAGE_GROSS_INCOME_CHANGE_FACTOR_CLIMATE_DESC
+	ADMIN_0_MACROECONOMIC_AVERAGE_GROSS_INCOME_CHANGE_FACTOR_CLIMATE_MARKET_ASC
+	ADMIN_0_MACROECONOMIC_AVERAGE_GROSS_INCOME_CHANGE_FACTOR_CLIMATE_MARKET_DESC
+	ADMIN_0_MACROECONOMIC_PRICE_OF_LIVING_ASC
+	ADMIN_0_MACROECONOMIC_PRICE_OF_LIVING_DESC
+	ADMIN_0_MACROECONOMIC_PRICE_OF_LIVING_CHANGE_FACTOR_CLIMATE_ASC
+	ADMIN_0_MACROECONOMIC_PRICE_OF_LIVING_CHANGE_FACTOR_CLIMATE_DESC
+	ADMIN_0_MACROECONOMIC_PRICE_OF_LIVING_CHANGE_FACTOR_CLIMATE_MARKET_ASC
+	ADMIN_0_MACROECONOMIC_PRICE_OF_LIVING_CHANGE_FACTOR_CLIMATE_MARKET_DESC
+	ADMIN_1_MACROECONOMIC_ECON_FACTOR_CLIMATE_ASC
+	ADMIN_1_MACROECONOMIC_ECON_FACTOR_CLIMATE_DESC
+	ADMIN_1_MACROECONOMIC_ECON_FACTOR_CLIMATE_MARKET_ASC
+	ADMIN_1_MACROECONOMIC_ECON_FACTOR_CLIMATE_MARKET_DESC
+	ADMIN_1_MACROECONOMIC_POPULATION_ASC
+	ADMIN_1_MACROECONOMIC_POPULATION_DESC
+	ADMIN_1_MACROECONOMIC_POPULATION_CHANGE_FACTOR_CLIMATE_ASC
+	ADMIN_1_MACROECONOMIC_POPULATION_CHANGE_FACTOR_CLIMATE_DESC
+	ADMIN_1_MACROECONOMIC_POPULATION_CHANGE_FACTOR_CLIMATE_MARKET_ASC
+	ADMIN_1_MACROECONOMIC_POPULATION_CHANGE_FACTOR_CLIMATE_MARKET_DESC
+	ADMIN_1_MACROECONOMIC_GDP_ASC
+	ADMIN_1_MACROECONOMIC_GDP_DESC
+	ADMIN_1_MACROECONOMIC_GDP_CHANGE_FACTOR_CLIMATE_ASC
+	ADMIN_1_MACROECONOMIC_GDP_CHANGE_FACTOR_CLIMATE_DESC
+	ADMIN_1_MACROECONOMIC_GDP_CHANGE_FACTOR_CLIMATE_MARKET_ASC
+	ADMIN_1_MACROECONOMIC_GDP_CHANGE_FACTOR_CLIMATE_MARKET_DESC
+	ADMIN_1_MACROECONOMIC_GDPPC_ASC
+	ADMIN_1_MACROECONOMIC_GDPPC_DESC
+	ADMIN_1_MACROECONOMIC_GDPPC_CHANGE_FACTOR_CLIMATE_ASC
+	ADMIN_1_MACROECONOMIC_GDPPC_CHANGE_FACTOR_CLIMATE_DESC
+	ADMIN_1_MACROECONOMIC_GDPPC_CHANGE_FACTOR_CLIMATE_MARKET_ASC
+	ADMIN_1_MACROECONOMIC_GDPPC_CHANGE_FACTOR_CLIMATE_MARKET_DESC
+	ADMIN_1_MACROECONOMIC_AVERAGE_GROSS_INCOME_ASC
+	ADMIN_1_MACROECONOMIC_AVERAGE_GROSS_INCOME_DESC
+	ADMIN_1_MACROECONOMIC_AVERAGE_GROSS_INCOME_CHANGE_FACTOR_CLIMATE_ASC
+	ADMIN_1_MACROECONOMIC_AVERAGE_GROSS_INCOME_CHANGE_FACTOR_CLIMATE_DESC
+	ADMIN_1_MACROECONOMIC_AVERAGE_GROSS_INCOME_CHANGE_FACTOR_CLIMATE_MARKET_ASC
+	ADMIN_1_MACROECONOMIC_AVERAGE_GROSS_INCOME_CHANGE_FACTOR_CLIMATE_MARKET_DESC
+	ADMIN_1_MACROECONOMIC_AVERAGE_GROSS_INCOME_LIVING_ASC
+	ADMIN_1_MACROECONOMIC_PRICE_OF_LIVING_ASC
+	ADMIN_1_MACROECONOMIC_PRICE_OF_LIVING_DESC
+	ADMIN_1_MACROECONOMIC_PRICE_OF_LIVING_CHANGE_FACTOR_CLIMATE_ASC
+	ADMIN_1_MACROECONOMIC_PRICE_OF_LIVING_CHANGE_FACTOR_CLIMATE_DESC
+	ADMIN_1_MACROECONOMIC_PRICE_OF_LIVING_CHANGE_FACTOR_CLIMATE_MARKET_ASC
+	ADMIN_1_MACROECONOMIC_PRICE_OF_LIVING_CHANGE_FACTOR_CLIMATE_MARKET_DESC
+	ADMIN_2_MACROECONOMIC_ECON_FACTOR_CLIMATE_ASC
+	ADMIN_2_MACROECONOMIC_ECON_FACTOR_CLIMATE_DESC
+	ADMIN_2_MACROECONOMIC_ECON_FACTOR_CLIMATE_MARKET_ASC
+	ADMIN_2_MACROECONOMIC_ECON_FACTOR_CLIMATE_MARKET_DESC
+	ADMIN_2_MACROECONOMIC_POPULATION_ASC
+	ADMIN_2_MACROECONOMIC_POPULATION_DESC
+	ADMIN_2_MACROECONOMIC_POPULATION_CHANGE_FACTOR_CLIMATE_ASC
+	ADMIN_2_MACROECONOMIC_POPULATION_CHANGE_FACTOR_CLIMATE_DESC
+	ADMIN_2_MACROECONOMIC_POPULATION_CHANGE_FACTOR_CLIMATE_MARKET_ASC
+	ADMIN_2_MACROECONOMIC_POPULATION_CHANGE_FACTOR_CLIMATE_MARKET_DESC
+	ADMIN_2_MACROECONOMIC_GDP_ASC
+	ADMIN_2_MACROECONOMIC_GDP_DESC
+	ADMIN_2_MACROECONOMIC_GDP_CHANGE_FACTOR_CLIMATE_ASC
+	ADMIN_2_MACROECONOMIC_GDP_CHANGE_FACTOR_CLIMATE_DESC
+	ADMIN_2_MACROECONOMIC_GDP_CHANGE_FACTOR_CLIMATE_MARKET_ASC
+	ADMIN_2_MACROECONOMIC_GDP_CHANGE_FACTOR_CLIMATE_MARKET_DESC
+	ADMIN_2_MACROECONOMIC_GDPPC_ASC
+	ADMIN_2_MACROECONOMIC_GDPPC_DESC
+	ADMIN_2_MACROECONOMIC_GDPPC_CHANGE_FACTOR_CLIMATE_ASC
+	ADMIN_2_MACROECONOMIC_GDPPC_CHANGE_FACTOR_CLIMATE_DESC
+	ADMIN_2_MACROECONOMIC_GDPPC_CHANGE_FACTOR_CLIMATE_MARKET_ASC
+	ADMIN_2_MACROECONOMIC_GDPPC_CHANGE_FACTOR_CLIMATE_MARKET_DESC
+	ADMIN_2_MACROECONOMIC_AVERAGE_GROSS_INCOME_ASC
+	ADMIN_2_MACROECONOMIC_AVERAGE_GROSS_INCOME_DESC
+	ADMIN_2_MACROECONOMIC_AVERAGE_GROSS_INCOME_CHANGE_FACTOR_CLIMATE_ASC
+	ADMIN_2_MACROECONOMIC_AVERAGE_GROSS_INCOME_CHANGE_FACTOR_CLIMATE_DESC
+	ADMIN_2_MACROECONOMIC_AVERAGE_GROSS_INCOME_CHANGE_FACTOR_CLIMATE_MARKET_ASC
+	ADMIN_2_MACROECONOMIC_AVERAGE_GROSS_INCOME_CHANGE_FACTOR_CLIMATE_MARKET_DESC
+	ADMIN_2_MACROECONOMIC_PRICE_OF_LIVING_ASC
+	ADMIN_2_MACROECONOMIC_PRICE_OF_LIVING_DESC
+	ADMIN_2_MACROECONOMIC_PRICE_OF_LIVING_CHANGE_FACTOR_CLIMATE_ASC
+	ADMIN_2_MACROECONOMIC_PRICE_OF_LIVING_CHANGE_FACTOR_CLIMATE_DESC
+	ADMIN_2_MACROECONOMIC_PRICE_OF_LIVING_CHANGE_FACTOR_CLIMATE_MARKET_ASC
+	ADMIN_2_MACROECONOMIC_PRICE_OF_LIVING_CHANGE_FACTOR_CLIMATE_MARKET_DESC
+	METRO_MACROECONOMIC_ECON_FACTOR_CLIMATE_ASC
+	METRO_MACROECONOMIC_ECON_FACTOR_CLIMATE_DESC
+	METRO_MACROECONOMIC_ECON_FACTOR_CLIMATE_MARKET_ASC
+	METRO_MACROECONOMIC_ECON_FACTOR_CLIMATE_MARKET_DESC
+	METRO_MACROECONOMIC_POPULATION_ASC
+	METRO_MACROECONOMIC_POPULATION_DESC
+	METRO_MACROECONOMIC_POPULATION_CHANGE_FACTOR_CLIMATE_ASC
+	METRO_MACROECONOMIC_POPULATION_CHANGE_FACTOR_CLIMATE_DESC
+	METRO_MACROECONOMIC_POPULATION_CHANGE_FACTOR_CLIMATE_MARKET_ASC
+	METRO_MACROECONOMIC_POPULATION_CHANGE_FACTOR_CLIMATE_MARKET_DESC
+	METRO_MACROECONOMIC_GDP_ASC
+	METRO_MACROECONOMIC_GDP_DESC
+	METRO_MACROECONOMIC_GDP_CHANGE_FACTOR_CLIMATE_ASC
+	METRO_MACROECONOMIC_GDP_CHANGE_FACTOR_CLIMATE_DESC
+	METRO_MACROECONOMIC_GDP_CHANGE_FACTOR_CLIMATE_MARKET_ASC
+	METRO_MACROECONOMIC_GDP_CHANGE_FACTOR_CLIMATE_MARKET_DESC
+	METRO_MACROECONOMIC_GDPPC_ASC
+	METRO_MACROECONOMIC_GDPPC_DESC
+	METRO_MACROECONOMIC_GDPPC_CHANGE_FACTOR_CLIMATE_ASC
+	METRO_MACROECONOMIC_GDPPC_CHANGE_FACTOR_CLIMATE_DESC
+	METRO_MACROECONOMIC_GDPPC_CHANGE_FACTOR_CLIMATE_MARKET_ASC
+	METRO_MACROECONOMIC_GDPPC_CHANGE_FACTOR_CLIMATE_MARKET_DESC
+	METRO_MACROECONOMIC_AVERAGE_GROSS_INCOME_ASC
+	METRO_MACROECONOMIC_AVERAGE_GROSS_INCOME_DESC
+	METRO_MACROECONOMIC_AVERAGE_GROSS_INCOME_CHANGE_FACTOR_CLIMATE_ASC
+	METRO_MACROECONOMIC_AVERAGE_GROSS_INCOME_CHANGE_FACTOR_CLIMATE_DESC
+	METRO_MACROECONOMIC_AVERAGE_GROSS_INCOME_CHANGE_FACTOR_CLIMATE_MARKET_ASC
+	METRO_MACROECONOMIC_AVERAGE_GROSS_INCOME_CHANGE_FACTOR_CLIMATE_MARKET_DESC
+	METRO_MACROECONOMIC_PRICE_OF_LIVING_ASC
+	METRO_MACROECONOMIC_PRICE_OF_LIVING_DESC
+	METRO_MACROECONOMIC_PRICE_OF_LIVING_CHANGE_FACTOR_CLIMATE_ASC
+	METRO_MACROECONOMIC_PRICE_OF_LIVING_CHANGE_FACTOR_CLIMATE_DESC
+	METRO_MACROECONOMIC_PRICE_OF_LIVING_CHANGE_FACTOR_CLIMATE_MARKET_ASC
+	METRO_MACROECONOMIC_PRICE_OF_LIVING_CHANGE_FACTOR_CLIMATE_MARKET_DESC
 }
 
 """
 Filter for module asset sections sorting
 """
 input AssetSortFilter {
-    ssp: SSP
-    relativeYear: Int
-    returnPeriod: ReturnPeriod
-    percentile: Int
-    perilId: Int
-    threshold: Int
+	ssp: SSP
+	relativeYear: Int
+	returnPeriod: ReturnPeriod
+	percentile: Int
+	perilId: Int
+	threshold: Int
+	adminLevel: AdministrativeLevel
+}
+
+"""
+Asset status, resolved at query time from job records.
+"""
+enum AssetStatus {
+	"""
+	The asset is up to date.
+	"""
+	UPDATED
+
+	"""
+	The asset is currently processing.
+	"""
+	PROCESSING
+
+	"""
+	The latest job for this asset has failed.
+	"""
+	FAILED
 }
 
 type AssetType {
-    id: AssetTypeId!
-    description: String!
+	id: AssetTypeId!
+	description: String!
 }
 
 enum AssetTypeId {
-    S1
-    S2
-    M1
-    M2
-    M3
-    M4
-    M5
-    M6
-    M7
-    M8
-    M9
-    H1
-    H2
-    H3
-    H4
-    H5
-    H6
-    O1
-    O2
-    O3
-    O4
-    O5
-    O6
-    R1
-    R2
-    R3
-    R4
-    X1
-    X2
-    X3
-    I1
-    I2
-    I3
-    I4
-    I5
-    I6
-    I7
-    I8
-    I9
-    W1
-    W2
-    W3
-    W4
-    W5
-    W6
-    W7
-    L1
-    R5
-    L2
-    L3
-    L4
-    L5
-    L6
-    L7
-    N1
-    N2
-    N3
-    N4
-    N5
-    N6
-    N7
-    N8
-    N9
-    NS
-    A1
-    A2
-    V1
-    V2
-    V3
+	"""
+	LAND - Agricultural Land
+	"""
+	A1
+
+	"""
+	LAND - Timber Land
+	"""
+	A2
+
+	"""
+	HOTEL - Motel
+	"""
+	H1
+
+	"""
+	HOTEL - Full Service (Mid-Rise)
+	"""
+	H2
+
+	"""
+	HOTEL - Full Service (Low-Rise)
+	"""
+	H3
+
+	"""
+	HOTEL - Limited Service (Mid-Rise)
+	"""
+	H4
+
+	"""
+	HOTEL - Limited Service (Low-Rise)
+	"""
+	H5
+
+	"""
+	HOTEL - Resort
+	"""
+	H6
+
+	"""
+	INDUSTRIAL - Large Manufacturing
+	"""
+	I1
+
+	"""
+	INDUSTRIAL - Small Manufacturing
+	"""
+	I2
+
+	"""
+	INDUSTRIAL - Flex - General Purpose Flex
+	"""
+	I3
+
+	"""
+	INDUSTRIAL - Flex - Research & Development
+	"""
+	I4
+
+	"""
+	INDUSTRIAL - Flex - Office/Showroom
+	"""
+	I5
+
+	"""
+	INDUSTRIAL - Life Science
+	"""
+	I6
+
+	"""
+	INDUSTRIAL - Specialized Industrial - Mixed Industrial Portfolio
+	"""
+	I7
+
+	"""
+	SPECIALTY - Data Center
+	"""
+	I8
+
+	"""
+	INDUSTRIAL - Laboratory
+	"""
+	I9
+
+	"""
+	SPECIALTY - Educational Facilities
+	"""
+	L1
+
+	"""
+	SPECIALTY - Public Buildings/Government
+	"""
+	L2
+
+	"""
+	SPECIALTY - Sports Facilities (stadiums, arenas)
+	"""
+	L3
+
+	"""
+	SPECIALTY - Entertainment (theaters, golf courses, etc.)
+	"""
+	L4
+
+	"""
+	SPECIALTY - Healthcare (hospitals, clinics beyond medical office)
+	"""
+	L5
+
+	"""
+	SPECIALTY - Parking (structures)
+	"""
+	L6
+
+	"""
+	SPECIALTY - Parking (surface lots)
+	"""
+	L7
+
+	"""
+	RESIDENTIAL - Apartment/Condo - Low-Rise (1-4 stories)
+	"""
+	M1
+
+	"""
+	RESIDENTIAL - Apartment/Condo - Mid-Rise (5-10 stories)
+	"""
+	M2
+
+	"""
+	RESIDENTIAL - Apartment/Condo - High-Rise (11+ stories)
+	"""
+	M3
+
+	"""
+	RESIDENTIAL - Apartment/Condo - Age-Restricted
+	"""
+	M4
+
+	"""
+	RESIDENTIAL - Student Housing - Low-Rise (1-4 stories)
+	"""
+	M5
+
+	"""
+	RESIDENTIAL - Student Housing - Mid-Rise (5-10 stories)
+	"""
+	M6
+
+	"""
+	RESIDENTIAL - Student Housing - High-Rise (11+ stories)
+	"""
+	M7
+
+	"""
+	SENIOR HOUSING - Independent Living
+	"""
+	M8
+
+	"""
+	SENIOR HOUSING - Assisted Living
+	"""
+	M9
+
+	"""
+	INFRASTRUCTURE – Transportation – Airport terminals
+	"""
+	N1
+
+	"""
+	INFRASTRUCTURE – Energy – Power Plants (hydropower, nuclear, gas, oil, coal)
+	"""
+	N2
+
+	"""
+	INFRASTRUCTURE – Energy – Electric Transmission & Distribution
+	"""
+	N3
+
+	"""
+	INFRASTRUCTURE – Utilities – Water & Wastewater Treatment
+	"""
+	N4
+
+	"""
+	INFRASTRUCTURE – Utilities – Waste Management
+	"""
+	N5
+
+	"""
+	INFRASTRUCTURE – Energy – Wind Turbines
+	"""
+	N6
+
+	"""
+	INFRASTRUCTURE – Utilities – Utility Poles
+	"""
+	N7
+
+	"""
+	INFRASTRUCTURE – Energy – Oil Refineries
+	"""
+	N8
+
+	"""
+	INFRASTRUCTURE – Communications – Cell Tower
+	"""
+	N9
+
+	"""
+	INFRASTRUCTURE – Utilities – Fiber-Optic Networks
+	"""
+	NF
+
+	"""
+	INFRASTRUCTURE – Transportation – Roads & Highways
+	"""
+	NH
+
+	"""
+	INFRASTRUCTURE – Energy – Transmission Line
+	"""
+	NI
+
+	"""
+	INFRASTRUCTURE – Transportation – Pipelines (Oil, Gas, Water)
+	"""
+	NP
+
+	"""
+	INFRASTRUCTURE – Utilities – Irrigation Canals & Aqueducts
+	"""
+	NQ
+
+	"""
+	INFRASTRUCTURE – Transportation – Railroads
+	"""
+	NR
+
+	"""
+	INFRASTRUCTURE – Energy – Solar Power Plants
+	"""
+	NS
+
+	"""
+	INFRASTRUCTURE – Transportation – Urban Transit
+	"""
+	NU
+
+	"""
+	OFFICE - Urban / Low-Rise (1-4 stories)
+	"""
+	O1
+
+	"""
+	OFFICE - Suburban / Low-Rise (1-4 stories)
+	"""
+	O2
+
+	"""
+	OFFICE - Medical Office
+	"""
+	O3
+
+	"""
+	OFFICE - Life Science Office
+	"""
+	O4
+
+	"""
+	OFFICE - CBD / High-Rise (11+ stories)
+	"""
+	O5
+
+	"""
+	OFFICE - Secondary Business District / Mid-Rise (5-10 stories)
+	"""
+	O6
+
+	"""
+	RETAIL - Mall
+	"""
+	R1
+
+	"""
+	RETAIL - Street Retail
+	"""
+	R2
+
+	"""
+	RETAIL - Strip Center
+	"""
+	R3
+
+	"""
+	RETAIL - Big Box
+	"""
+	R4
+
+	"""
+	SPECIALTY - Gas Station
+	"""
+	R5
+
+	"""
+	RESIDENTIAL - Single-Family
+	"""
+	S1
+
+	"""
+	RESIDENTIAL - Manufactured Housing
+	"""
+	S2
+
+	"""
+	LAND - Development Land (non-income producing)
+	"""
+	V1
+
+	"""
+	LAND - Vacant Land
+	"""
+	V2
+
+	"""
+	LAND - Operating Land
+	"""
+	V3
+
+	"""
+	INDUSTRIAL - General Purpose Warehouse (500,000 sf)
+	"""
+	W1
+
+	"""
+	INDUSTRIAL - General Purpose Warehouse (25,000 sf)
+	"""
+	W2
+
+	"""
+	INDUSTRIAL - Distribution Warehouse
+	"""
+	W3
+
+	"""
+	INDUSTRIAL - Specialized Industrial - Refrigerated Storage
+	"""
+	W4
+
+	"""
+	INDUSTRIAL - Specialized Industrial - Air Cargo
+	"""
+	W5
+
+	"""
+	INDUSTRIAL - Specialized Industrial - Truck Terminal
+	"""
+	W6
+
+	"""
+	SELF-STORAGE
+	"""
+	W7
+
+	"""
+	MIXED USE - Low-Rise (1-4 stories)
+	"""
+	X1
+
+	"""
+	MIXED USE - Mid-Rise (5-10 stories)
+	"""
+	X2
+
+	"""
+	MIXED USE - High-Rise (11+ stories)
+	"""
+	X3
+}
+
+type AssetValueChain {
+	"""
+	Asset primary valuechain id
+	"""
+	id: Int64!
+
+	"""
+	Asset primary valuechain name
+	"""
+	name: String!
 }
 
 """
 Details for property wildfire losses.
 """
 type AssetWildfireDamages {
-    asset(filterBy: AssetSortFilter): [AssetWildfireDamagesAsset!]
+	asset(filterBy: AssetSortFilter): [AssetWildfireDamagesAsset!]
 
-    """
-    Annualized damage cost to the structure in the current year due to wildfire
-    """
-    aal(filterBy: AssetSortFilter): [AssetWildfireDamagesAAL!]
+	"""
+	Annualized damage cost to the structure in the current year due to wildfire
+	"""
+	aal(filterBy: AssetSortFilter): [AssetWildfireDamagesAAL!]
 }
 
 """
 Annualized damage cost to the structure in the current year due to wildfire.
 """
 type AssetWildfireDamagesAAL {
-    """
-    Socio-economic pathway of the prediction model.
-    """
-    ssp: SSP!
+	"""
+	Socio-economic pathway of the prediction model.
+	"""
+	ssp: SSP!
 
-    """
-    Year, as relative to the current year.
-    """
-    relativeYear: Int!
+	"""
+	Year, as relative to the current year.
+	"""
+	relativeYear: Int!
 
-    """
-    Percentile value for estimates, one of: 10, 50, 90. 10th percentile estimate is low value, 90th percentile is high value, and 50th is mean.
-    """
-    percentile: Int!
+	"""
+	Percentile value for estimates, one of: 10, 50, 90. 10th percentile estimate is low value, 90th percentile is high value, and 50th is mean.
+	"""
+	percentile: Int!
 
-    """
-    Annualized damage cost to the structure in the current year due to wildfire.
-    """
-    aal: Float
+	"""
+	Annualized damage cost to the structure in the current year due to wildfire.
+	"""
+	aal: Float
+
+	"""
+	Average annual downtime in days.
+	"""
+	repairDays: Int
+
+	"""
+	Average annual downtime in forgone revenue. Assumes that every day of the year has the same revenue (1/365.25 share of the annual revenue)
+	"""
+	interruptionLoss: Int64
+
+	"""
+	Sum of AAL and average annual interruption loss.
+	"""
+	cashLoss: Int64
+
+	"""
+	Annualized cost from lost inventory, lost contents, and business interruption in the given modeled event. NULL if contents or inventory curve is unavailable for given asset type, or if NOI (revenue) is missing.
+	"""
+	operatorLoss: Int64
+
+	"""
+	Cumulative annualized cost from lost inventory, lost contents, and business interruption in the given modeled event. NULL if contents or inventory curve is unavailable for given asset type, or if NOI (revenue) is missing.
+	"""
+	operatorLossCumulative: Int64
 }
 
 type AssetWildfireDamagesAsset {
-    """
-    Socio-economic pathway of the prediction model.
-    """
-    ssp: SSP!
+	"""
+	Socio-economic pathway of the prediction model.
+	"""
+	ssp: SSP!
 
-    """
-    Year, as relative to the current year.
-    """
-    relativeYear: Int!
+	"""
+	Year, as relative to the current year.
+	"""
+	relativeYear: Int!
 
-    """
-    Percentile value for estimates, one of: 10, 50, 90. 10th percentile estimate is low value, 90th percentile is high value, and 50th is mean.
-    """
-    percentile: Int!
+	"""
+	Percentile value for estimates, one of: 10, 50, 90. 10th percentile estimate is low value, 90th percentile is high value, and 50th is mean.
+	"""
+	percentile: Int!
 
-    """
-    Estimated number of days to rebuild or repair damage due to wildfire.
-    """
-    repairDays: Int
+	"""
+	Estimated number of days to rebuild or repair damage due to wildfire.
+	"""
+	repairDays: Int
 
-    """
-    Probability of asset combustion by flames given a modeled wildfire and based on asset characteristics.
-    """
-    combustionProbability: Float
+	"""
+	Probability of asset combustion by flames given a modeled wildfire and based on asset characteristics.
+	"""
+	combustionProbability: Float
 
-    """
-    Probability of wildfire flames destroying asset in given year.
-    """
-    destructionProbability: Float
+	"""
+	Probability of wildfire flames destroying asset in given year.
+	"""
+	destructionProbability: Float
 
-    """
-    Cumulative probability of wildfire flames destroying asset up to given year.
-    """
-    cumulativeDestructionProbability: Float
+	"""
+	Cumulative probability of wildfire flames destroying asset up to given year.
+	"""
+	cumulativeDestructionProbability: Float
+
+	"""
+	Estimated downtime loss of revenue due to wildfire.
+	"""
+	interruptionLoss: Int64
+
+	"""
+	Sum of repair cost, interruption loss and losses to contents and inventory due to wildfire.
+	"""
+	cashLoss: Int64
+
+	"""
+	Cost from lost inventory, lost contents, and business interruption in the given modeled event. NULL if contents or inventory curve is unavailable for given asset type, or if NOI (revenue) is missing.
+	"""
+	operatorLoss: Int64
 }
 
 """
 Fire probability details for asset.
 """
 type AssetWildfireProbability {
-    """
-    Wildfire probability details for asset
-    """
-    burn(filterBy: AssetSortFilter): [AssetWildfireProbabilityBurn]
+	"""
+	Wildfire probability details for asset
+	"""
+	burn(filterBy: AssetSortFilter): [AssetWildfireProbabilityBurn]
 
-    """
-    The wildfire risk likelihood (% probability) to the asset footprint by cumulative year based on combined wildfire risk (greater of burn and ember).
-    """
-    cumulative(filterBy: AssetSortFilter): [AssetWildfireProbabilityCumulative!]
+	"""
+	The wildfire risk likelihood (% probability) to the asset footprint by cumulative year based on combined wildfire risk (greater of burn and ember).
+	"""
+	cumulative(filterBy: AssetSortFilter): [AssetWildfireProbabilityCumulative!]
 }
 
 type AssetWildfireProbabilityBurn {
-    """
-    Socio-economic pathway of the prediction model.
-    """
-    ssp: SSP!
+	"""
+	Socio-economic pathway of the prediction model.
+	"""
+	ssp: SSP!
 
-    """
-    Year, as relative to the current year.
-    """
-    relativeYear: Int!
+	"""
+	Year, as relative to the current year.
+	"""
+	relativeYear: Int!
 
-    """
-    The probability of wildfire flamesreaching this building.
-    """
-    flameProbability: Float
+	"""
+	The probability of wildfire flamesreaching this building.
+	"""
+	flameProbability: Float
 
-    """
-    The probability of wildfire embers reaching this building.
-    """
-    emberProbability: Float
+	"""
+	The probability of wildfire embers reaching this building.
+	"""
+	emberProbability: Float
 
-    """
-    The probability of wildfire flames or embers reaching this building.
-    """
-    probability: Float
+	"""
+	The probability of wildfire flames or embers reaching this building.
+	"""
+	probability: Float
 }
 
 type AssetWildfireProbabilityCumulative {
-    """
-    Socio-economic pathway of the prediction model.
-    """
-    ssp: SSP!
+	"""
+	Socio-economic pathway of the prediction model.
+	"""
+	ssp: SSP!
 
-    """
-    Year, as relative to the current year.
-    """
-    relativeYear: Int!
+	"""
+	Year, as relative to the current year.
+	"""
+	relativeYear: Int!
 
-    """
-    Cumulative probability of wildfire flamesreaching this building.
-    """
-    flameProbability: Float
+	"""
+	Cumulative probability of wildfire flamesreaching this building.
+	"""
+	flameProbability: Float
 
-    """
-    Cumulative probability of wildfire embers reaching this building.
-    """
-    emberProbability: Float
+	"""
+	Cumulative probability of wildfire embers reaching this building.
+	"""
+	emberProbability: Float
 
-    """
-    Cumulative probability of wildfire flames at the given place.
-    """
-    probability: Float
+	"""
+	Cumulative probability of wildfire flames at the given place.
+	"""
+	probability: Float
 }
 
 """
 Details for property wind damages.
 """
 type AssetWindDamages {
-    """
-    Annualized damage cost to the structure in the current year due to wind.
-    """
-    asset(filterBy: AssetSortFilter): [AssetWindDamagesAsset!]
+	"""
+	Annualized damage cost to the structure in the current year due to wind.
+	"""
+	asset(filterBy: AssetSortFilter): [AssetWindDamagesAsset!]
 
-    """
-    Annualized damage cost to the structure in the current year due to wind.
-    """
-    aal(filterBy: AssetSortFilter): [AssetWindDamagesAAL!]
+	"""
+	Annualized damage cost to the structure in the current year due to wind.
+	"""
+	aal(filterBy: AssetSortFilter): [AssetWindDamagesAAL!]
 }
 
 """
 Annualized damage cost to the structure in the current year due to wind.
 """
 type AssetWindDamagesAAL {
-    """
-    Socio-economic pathway of the prediction model.
-    """
-    ssp: SSP!
+	"""
+	Socio-economic pathway of the prediction model.
+	"""
+	ssp: SSP!
 
-    """
-    Year, as relative to the current year.
-    """
-    relativeYear: Int!
+	"""
+	Year, as relative to the current year.
+	"""
+	relativeYear: Int!
 
-    """
-    Percentile value for estimates, one of: 10, 50, 90. 10th percentile estimate is low value, 90th percentile is high value, and 50th is mean.
-    """
-    percentile: Int!
+	"""
+	Percentile value for estimates, one of: 10, 50, 90. 10th percentile estimate is low value, 90th percentile is high value, and 50th is mean.
+	"""
+	percentile: Int!
 
-    """
-    Annualized damage cost to the structure due to wind.
-    """
-    aal: Float
+	"""
+	Annualized damage cost to the structure due to wind.
+	"""
+	aal: Float
+
+	"""
+	Average annual downtime in days.
+	"""
+	repairDays: Int
+
+	"""
+	Average annual downtime in forgone revenue. Assumes that every day of the year has the same revenue (1/365.25 share of the annual revenue)
+	"""
+	interruptionLoss: Int64
+
+	"""
+	Sum of AAL and average annual interruption loss.
+	"""
+	cashLoss: Int64
+
+	"""
+	Annualized cost from lost inventory, lost contents, and business interruption in the given modeled event. NULL if contents or inventory curve is unavailable for given asset type, or if NOI (revenue) is missing.
+	"""
+	operatorLoss: Int64
+
+	"""
+	Cumulative annualized cost from lost inventory, lost contents, and business interruption in the given modeled event. NULL if contents or inventory curve is unavailable for given asset type, or if NOI (revenue) is missing.
+	"""
+	operatorLossCumulative: Int64
 }
 
 type AssetWindDamagesAsset {
-    """
-    Socio-economic pathway of the prediction model.
-    """
-    ssp: SSP!
+	"""
+	Socio-economic pathway of the prediction model.
+	"""
+	ssp: SSP!
 
-    """
-    Year, as relative to the current year.
-    """
-    relativeYear: Int!
+	"""
+	Year, as relative to the current year.
+	"""
+	relativeYear: Int!
 
-    """
-    Return period for the wind probability.
-    """
-    returnPeriod: ReturnPeriod!
+	"""
+	Return period for the wind probability.
+	"""
+	returnPeriod: ReturnPeriod!
 
-    """
-    Percentile value for estimates, one of: 10, 50, 90. 10th percentile estimate is low value, 90th percentile is high value, and 50th is mean.
-    """
-    percentile: Int!
+	"""
+	Percentile value for estimates, one of: 10, 50, 90. 10th percentile estimate is low value, 90th percentile is high value, and 50th is mean.
+	"""
+	percentile: Int!
 
-    """
-    Estimated number of days to rebuild or repair damage due to wind.
-    """
-    repairDays: Float
+	"""
+	Estimated number of days to rebuild or repair damage due to wind.
+	"""
+	repairDays: Float
 
-    """
-    Estimated cost to repair damage due to wind.
-    """
-    repairCost: Float
+	"""
+	Estimated cost to repair damage due to wind.
+	"""
+	repairCost: Float
+
+	"""
+	Estimated downtime loss of revenue due to wind.
+	"""
+	interruptionLoss: Int64
+
+	"""
+	Sum of repair cost, interruption loss and losses to contents and inventory due to wind.
+	"""
+	cashLoss: Int64
+
+	"""
+	Cost from lost inventory, lost contents, and business interruption in the given modeled event. NULL if contents or inventory curve is unavailable for given asset type, or if NOI (revenue) is missing.
+	"""
+	operatorLoss: Int64
 }
 
 """
 Forecast probability
 """
 type AssetWindProbability {
-    """
-    Probability for wind speeds.
-    """
-    speed(
-        """
-        Filter the array of data based on filterBy, this is a further filtering based on result of projectAssetConnection level filter / sorting.
-        """
-        filterBy: AssetSortFilter
-    ): [AssetWindProbabilitySpeed!]
+	"""
+	Probability for wind speeds.
+	"""
+	speed(
+		"""
+		Filter the array of data based on filterBy, this is a further filtering based on result of projectAssetConnection level filter / sorting.
+		"""
+		filterBy: AssetSortFilter
+	): [AssetWindProbabilitySpeed!]
 
-    """
-    Cumulative probability of 3-sec wind gusts of a given speed (threshold) reaching the building.
-    """
-    cumulative(filterBy: AssetSortFilter): [AssetWindProbabilityCumulative]
+	"""
+	Cumulative probability of 3-sec wind gusts of a given speed (threshold) reaching the building.
+	"""
+	cumulative(filterBy: AssetSortFilter): [AssetWindProbabilityCumulative]
 }
 
 type AssetWindProbabilityCumulative {
-    """
-    Socio-economic pathway of the prediction model.
-    """
-    ssp: SSP!
+	"""
+	Socio-economic pathway of the prediction model.
+	"""
+	ssp: SSP!
 
-    """
-    Year, as relative to the current year.
-    """
-    relativeYear: Int!
+	"""
+	Year, as relative to the current year.
+	"""
+	relativeYear: Int!
 
-    """
-    Wind 3-sec speed threshold for the probability.
-    """
-    threshold: Float
+	"""
+	Wind 3-sec speed threshold for the probability.
+	"""
+	threshold: Float
 
-    """
-    Cumulative probability of winds of a given speed (3-sec) reaching the building.
-    """
-    probability: Float
+	"""
+	Cumulative probability of winds of a given speed (3-sec) reaching the building.
+	"""
+	probability: Float
 }
 
 """
 Probability for wind speeds
 """
 type AssetWindProbabilitySpeed {
-    """
-    Socio-economic pathway of the prediction model.
-    """
-    ssp: SSP!
+	"""
+	Socio-economic pathway of the prediction model.
+	"""
+	ssp: SSP!
 
-    """
-    Year, as relative to the current year.
-    """
-    relativeYear: Int!
+	"""
+	Year, as relative to the current year.
+	"""
+	relativeYear: Int!
 
-    """
-    Return period for the wind probability.
-    """
-    returnPeriod: ReturnPeriod!
+	"""
+	Return period for the wind probability.
+	"""
+	returnPeriod: ReturnPeriod!
 
-    """
-    The maximum 3-second gust speed for a given return period.
-    """
-    speed3Sec: Float
+	"""
+	The maximum 3-second gust speed for a given return period.
+	"""
+	speed3Sec: Float
 }
 
 enum Basement {
-    NONE
-    UNFINISHED
-    FINISHED
+	NONE
+	UNFINISHED
+	FINISHED
+}
+
+"""
+A bounding box enclosing a geometry.
+The bounding box is defined as a set of 4 coordinates: [{southwest lng}, {southwest lat}, {northeast lng}, {northeast lat}]
+"""
+type BoundingBox {
+	"""
+	The longitude of the southwest corner of the bounding box.
+	"""
+	southWestLng: Float!
+
+	"""
+	The latitude of the southwest corner of the bounding box.
+	"""
+	southWestLat: Float!
+
+	"""
+	The longitude of the northeast corner of the bounding box.
+	"""
+	northEastLng: Float!
+
+	"""
+	The latitude of the northeast corner of the bounding box.
+	"""
+	northEastLat: Float!
+}
+
+type BucketStat {
+	count: Int
+	percent: Float
 }
 
 type ClimateExposureData {
-    hazardExposure(input: ClimateExposureHazardExposureInput): [HazardExposure]
-    hazardDamage(input: ClimateExposureHazardDamageInput): [HazardDamage]
+	hazardExposure(input: ClimateExposureHazardExposureInput): [HazardExposure]
+	hazardDamage(input: ClimateExposureHazardDamageInput): [HazardDamage]
+	hazardExposureStatistics: HazardExposureStatistics
+	portfolioPerilScore: [PortfolioPerilScore]
 }
 
 """
 The input to set the climate exposure tresholds.
 """
 input ClimateExposureHazardDamageInput {
-    """
-    Flood depth threshold (default $0)
-    """
-    floodDamageThreshold: Float
+	"""
+	Flood depth threshold (default $0)
+	"""
+	floodDamageThreshold: Float
 
-    """
-    Wind speed threshold (default $0)
-    """
-    windDamageThreshold: Int64
+	"""
+	Wind speed threshold (default $0)
+	"""
+	windDamageThreshold: Int64
 }
 
 """
 The input to set the climate exposure thresholds.
 """
 input ClimateExposureHazardExposureInput {
-    """
-    Flood depth threshold (default 0 ft)
-    """
-    floodDepthThreshold: Float
+	"""
+	Flood depth threshold (default 0 ft)
+	"""
+	floodDepthThreshold: Float
 
-    """
-    Wind speed threshold (default 50 mph)
-    """
-    windSpeedThreshold: Int64
+	"""
+	Wind speed threshold (default 50 mph)
+	"""
+	windSpeedThreshold: Int64
 
-    """
-    Drought length threshold (default 13 weeks)
-    """
-    droughtLengthThreshold: Int64
+	"""
+	Drought length threshold (default 13 weeks)
+	"""
+	droughtLengthThreshold: Int64
 
-    """
-    Heat days threshold (default 90 days)
-    """
-    heatDaysThreshold: Int64
+	"""
+	Heat days threshold (default 90 days)
+	"""
+	heatDaysThreshold: Int64
 
-    """
-    coldThreshold (default 90 days)
-    """
-    coldDaysThreshold: Int64
+	"""
+	coldThreshold (default 90 days)
+	"""
+	coldDaysThreshold: Int64
+}
+
+type ColdExposureStatistics {
+	"""
+	Socio-economic pathway of the prediction model.
+	"""
+	ssp: SSP!
+
+	"""
+	The relative year with current year being year 0.
+	"""
+	relativeYear: Int64!
+
+	"""
+	The temperature threshold in degrees Fahrenheit.
+	"""
+	coldTempThresholdF: Int64!
+
+	"""
+	The number of days threshold.
+	"""
+	daysThreshold: Int64!
+
+	"""
+	Maximum number of days in a portfolio with windchill at or below [coldTempThresholdF]
+	"""
+	maxWindChillDays: Int64!
+
+	"""
+	Average number of days in a portfolio with windchill at or below [coldTempThresholdF]
+	"""
+	avgWindChillDays: Int64!
+
+	"""
+	Number of assets exposed to [daysThreshold] or more days at or below [coldTempThresholdF] wind chill in the given scenario
+	"""
+	countCold: Int64!
+
+	"""
+	Percentage of assets exposed to [daysThreshold] or more days at or below [coldTempThresholdF] wind chill in the given scenario
+	"""
+	pctCold: Float!
 }
 
 """
 Describes a Company.
 """
 type Company {
-    """
-    All available names for the company.
-    """
-    names: [CompanyName!]
+	"""
+	All available names for the company.
+	"""
+	names: [CompanyName!]
 
-    """
-    ID of the company.
-    """
-    id: Int64!
+	"""
+	ID of the company.
+	"""
+	id: Int64!
 
-    """
-    The data source for the company metadata.
-    """
-    dataSource: CompanyDataSource!
+	"""
+	The data source for the company metadata.
+	"""
+	dataSource: CompanyDataSource!
 
-    """
-    Company annual net revenue.
-    """
-    revenueAnnualNet: Int64
+	"""
+	Company annual net revenue.
+	"""
+	revenueAnnualNet: Int64
 
-    """
-    FS-assigned ID describing the industry.
-    """
-    industryId: String!
+	"""
+	FS-assigned ID describing the industry.
+	"""
+	industryId: String @deprecated(reason: "replaced by company.industry.id")
 
-    """
-    FS-assigned ID describing the sector
-    """
-    sectorId: String!
+	"""
+	FS-assigned ID describing the sector.
+	"""
+	sectorId: String @deprecated(reason: "replaced by company.sector.id")
 
-    """
-    The ISO-4217 currency code used for this company.
-    """
-    currencyCode: String
+	"""
+	Where a company stands relative to its peers given the given
+	"""
+	peerRanking: Int64
+
+	"""
+	The company's sector.
+	"""
+	sector: Sector!
+
+	"""
+	The company's industry.
+	"""
+	industry: Industry!
+
+	"""
+	The ISO-4217 currency code used for this company.
+	"""
+	currencyCode: String
+
+	"""
+	The date when currency exchange rate was captured.
+	"""
+	exchangeRateDate: String
+
+	"""
+	The date when company annual revenue was captured.
+	"""
+	revenueDate: String
+
+	"""
+	Rationale of company revenue_at_risk assignment.
+	"""
+	rationaleRevenueAtRisk: String
+
+	"""
+	Rationale of company vc_revenue_at_risk assignment.
+	"""
+	rationaleVCRevenueAtRisk: String
+
+	"""
+	Location of the company headquarters.
+	"""
+	centroid: Coordinate
+
+	"""
+	Weights for each value chain position, used to assigning per-location revenue
+	"""
+	valueChainRevenueRealized: [ValueChainRevenueRealized!]
+
+	"""
+	Fractions of the company's revenue exposed to climate risk by value chain level
+	"""
+	valueChainRevenueAtRisk: [ValueChainRevenueAtRisk!]
 }
 
 """
 Where the company data was provided by.
 """
 enum CompanyDataSource {
-    DUNBRADSTREET
-    MSCI
+	DUNS
+	MSCI
+}
+
+input CompanyFilter {
+	"""
+	Filter to companies in this industry.
+	"""
+	industryId: Int64
+
+	"""
+	Filter to companies in this sector.
+	"""
+	sectorId: Int64
+
+	"""
+	Filters for company sorting. Required for peer ranking sorts.
+	"""
+	companySortFilter: CompanySortFilter
 }
 
 """
 Describes the name of a company.
 """
 type CompanyName {
-    """
-    Name of the company.
-    """
-    name: String!
+	"""
+	Name of the company.
+	"""
+	name: String!
 
-    """
-    One of Legal Name, Ticker Symbol (i.e NYSE: TM), DBA name, Duns Number, MSCI Corporation Code, etc.
-    """
-    nameType: CompanyNameType!
+	"""
+	One of Legal Name, Ticker Symbol (i.e NYSE: TM), DBA name, Duns Number, MSCI Corporation Code, etc.
+	"""
+	nameType: CompanyNameType!
 }
 
 """
 The representation type of company name as identified by its data source.
 """
 enum CompanyNameType {
-    TICKER
-    LEGAL_NAME
-    DBA_NAME
-    DUNS_NUMBER
-    MSCI_CODE
+	TICKER
+	LEGAL_NAME
+	DUNS_NAME
+	DUNS_NUMBER
+	MSCI_CODE
+	MSCI_NAME
+}
+
+type CompanyOverviewData {
+	valueChain: [ValueChainData]
+	risksByValueChain: [RisksByValueChainData!]
+	equityScore: [EquityScoreData]
+}
+
+"""
+The input to filter company sorting dimensions.
+"""
+input CompanySortFilter {
+	"""
+	The peril ID for peer ranking sorts. Default: 5 (overall).
+	Valid values: 2 (flood), 3 (hurricane), 4 (wildfire), 5 (overall).
+	"""
+	perilId: Int
+
+	"""
+	The SSP scenario for peer ranking sorts. Default: SSP_2_45.
+	"""
+	ssp: SSP
+
+	"""
+	The relative year for peer ranking sorts. Default: 0.
+	Valid values: 0 (current year), 30 (30 years out).
+	"""
+	relativeYear: Int
+
+	"""
+	The percentile for peer ranking sorts. Default: 50.
+	Valid values: 10, 50, 90.
+	"""
+	percentile: Int
 }
 
 enum CompassDirection {
-    N
-    NE
-    E
-    SE
-    S
-    SW
-    W
-    NW
+	N
+	NE
+	E
+	SE
+	S
+	SW
+	W
+	NW
+}
+
+type ComplexProperties {
+	"""
+	The "complex type" of the project. This is populated for projects that are not simple collections of lat/lng places,
+	for example, linear assets (e.g. roads, transmission lines) or area assets (e.g. solar arrays, undeveloped plots of land).
+
+	This field may be extended in the future to include other "complex" types, such as portfolios that contain other portfolios.
+	"""
+	type: ComplexType
+
+	"""
+	The project geometry in GeoJSON format.
+	"""
+	geometry: String
+
+	"""
+	The bounding box enclosing the project geometry.
+	"""
+	boundingBox: BoundingBox
+
+	"""
+	The length in meters of the complex asset. This is only populated when `type` = `LINEAR`.
+	"""
+	lengthM: Float
+
+	"""
+	The area in square meters of the complex asset. This is only populated when `type` = `AREA`.
+	"""
+	areaSqM: Float
+}
+
+"""
+For projects which are not simple collections of lat/lng places, this enum indicates what the project actually represents.
+
+Possibilities include:
+- linear assets (e.g. roads, transmission lines)
+- area assets (e.g. solar arrays, undeveloped plots of land)
+
+This enum can be extended in the future to include other "complex" types, such as portfolios that contain other portfolios.
+"""
+enum ComplexType {
+	LINEAR
+	AREA
 }
 
 enum ConstructionCombustibilityLevel {
-    LOW
-    MEDIUM
-    HIGH
+	LOW
+	MEDIUM
+	HIGH
 }
 
 enum ConstructionType {
-    ADOBE
-    BRICK
-    CONCRETE
-    CONCRETE_BLOCK
-    DOME
-    FRAME
-    HEAVY
-    LIGHT
-    LOG
-    MANUFACTURED
-    OTHER
-    MASONRY
-    METAL
-    STEEL
-    STONE
-    TILT_UP
-    WOOD
-    MIXED
+	ADOBE
+	BRICK
+	CONCRETE
+	CONCRETE_BLOCK
+	DOME
+	FRAME
+	HEAVY
+	LIGHT
+	LOG
+	MANUFACTURED
+	OTHER
+	MASONRY
+	METAL
+	STEEL
+	STONE
+	TILT_UP
+	WOOD
+	MIXED
+}
+
+type Coordinate {
+	"""
+	Latitude.
+	"""
+	lat: Float!
+
+	"""
+	Longitude.
+	"""
+	lng: Float!
+
+	"""
+	First Street place ID for the coordinate.
+	"""
+	placeId: String
+
+	"""
+	Administrative locality data (country, state, county, metro).
+	"""
+	locality: AssetLocality
+}
+
+input CopyPortfolioToNewParentInput {
+	"""
+	New parent portfolio ID of the portfolio to be cloned.
+	"""
+	targetParentPortfolioId: Int64!
+
+	"""
+	ID of the portfolio to be cloned
+	"""
+	portfolioId: Int64!
+
+	"""
+	The new project name. If omitted the cloned project name will be based off the original portfolio name.
+	"""
+	projectName: String
+}
+
+"""
+Portfolio subtree clone payload
+"""
+type CopyPortfolioToNewParentPayload {
+	clonePayloads: [ProjectClonePayload!]
 }
 
 """
 The payload of creating a project asset.
 """
 type CreateProjectAssetPayload {
-    """
-    The ID of the created project asset.
-    """
-    projectAssetId: String!
+	"""
+	The ID of the created project asset.
+	"""
+	projectAssetId: String!
 }
 
 """
 The input to create a project.
 """
 input CreateProjectInput {
-    """
-    The name of the project.
-    """
-    name: String!
+	"""
+	The name of the project.
+	"""
+	name: String!
 
-    """
-    The description of the project.
-    """
-    description: String
+	"""
+	The description of the project.
+	"""
+	description: String
 
-    """
-    Type of the project. Default value: CUSTOMER. Only service user is allowed to create a project with type EQUITY.
-    """
-    projectType: ProjectType
+	"""
+	Type of the project. Default value: CUSTOMER. Only service user is allowed to create a project with type EQUITY.
+	"""
+	projectType: ProjectType
+
+	"""
+	Optional parent project ID for creating child projects. NULL indicates root-level project.
+	"""
+	parentProjectId: Int64
 }
 
 """
 The input to create a project job.
 """
 input CreateProjectJobInput {
-    """
-    The name of the project job.
-    """
-    projectJobName: String!
+	"""
+	The name of the project job.
+	"""
+	projectJobName: String!
 
-    """
-    The ID of the user group that owns the project job.
-    """
-    userGroupId: Int
+	"""
+	The ID of the user group that owns the project job.
+	"""
+	userGroupId: Int
 }
 
 """
 The payload of creating a project job.
 """
 type CreateProjectJobPayload {
-    """
-    The created project job.
-    """
-    projectJob: ProjectJob!
+	"""
+	The created project job.
+	"""
+	projectJob: ProjectJob!
 }
 
 """
 Generate a link to upload a project.
 """
 input CreateProjectJobUploadLinkInput {
-    """
-    The name of the project job.
-    """
-    projectJobName: String!
+	"""
+	The name of the project job.
+	"""
+	projectJobName: String!
 
-    """
-    The file format of the project job file. (Default: CSV)
-    """
-    fileFormat: ProjectUploadFileFormat
+	"""
+	The file format of the project job file. (Default: CSV)
+	"""
+	fileFormat: ProjectUploadFileFormat
 
-    """
-    Custom headers to add to the uploaded file metadata. For internal use only.
-    """
-    customHeaders: [ProjectUploadHeadersInput]
+	"""
+	Custom headers to add to the uploaded file metadata. For internal use only.
+	"""
+	customHeaders: [ProjectUploadHeadersInput]
 }
 
 """
 The payload of creating a project job.
 """
 type CreateProjectJobUploadLinkPayload {
-    """
-    The created project job.
-    """
-    projectJob: ProjectJob!
+	"""
+	The created project job.
+	"""
+	projectJob: ProjectJob!
 
-    """
-    The link to upload the project job.
-    """
-    projectUploadLink: String!
+	"""
+	The link to upload the project job.
+	"""
+	projectUploadLink: String!
 
-    """
-    The headers that must be provided when uploading the project job.
-    """
-    projectUploadHeaders: [ProjectUploadHeaders]!
+	"""
+	The headers that must be provided when uploading the project job.
+	"""
+	projectUploadHeaders: [ProjectUploadHeaders]!
 }
 
 """
 The payload of creating a project.
 """
 type CreateProjectPayload {
-    """
-    The ID of the created project.
-    """
-    projectId: Int64!
+	"""
+	The ID of the created project.
+	"""
+	projectId: Int64!
+}
+
+input DashboardScoreFilter {
+	portfolioIds: [Int64!]
+	assetClasses: [ProjectAssetClass!]
+	assetTypeIds: [AssetTypeId!]
+	countryIds: [Int64!]
+	stateIds: [Int64!]
+	ssp: SSP
+	relativeYear: Int
 }
 
 scalar Date
 
+"""
+List of building edits that need to be deleted.
+"""
 input DeleteCustomBuildingValuesFieldsInput {
-    assetTypeId: Boolean
-    placeValuation: Boolean
-    placeOutstandingBalance: Boolean
-    placeNOI: Boolean
-    placeType: Boolean
-    rebuildCostPerSf: Boolean
-    buildingSf: Boolean
-    buildingDirection: Boolean
-    defensibleSpace: Boolean
-    units: Boolean
-    stories: Boolean
-    foundationHeightFt: Boolean
-    foundationType: Boolean
-    basement: Boolean
-    constructionType: Boolean
-    roofType: Boolean
-    yearBuilt: Boolean
-    fireProofing: Boolean
-    denseUrbanEnvironment: Boolean
-    windDesignStandard: Boolean
-    wildfireInsuredValue: Boolean
-    wildfireDeductible: Boolean
-    wildfireDeductiblePerc: Boolean
-    wildfireBICoverageIncluded: Boolean
-    windInsuredValue: Boolean
-    windDeductible: Boolean
-    windDeductiblePerc: Boolean
-    windBICoverageIncluded: Boolean
-    floodInsuredValue: Boolean
-    floodDeductible: Boolean
-    floodDeductiblePerc: Boolean
-    floodBICoverageIncluded: Boolean
+	alias: Boolean
+	assetTypeId: Boolean
+	placeValuation: Boolean
+	placeOutstandingBalance: Boolean
+	placeNOI: Boolean
+	placeType: Boolean
+	rebuildCostPerSf: Boolean
+	buildingSf: Boolean
+	buildingDirection: Boolean
+	defensibleSpace: Boolean
+	units: Boolean
+	stories: Boolean
+	foundationHeightFt: Boolean
+	foundationType: Boolean
+	basement: Boolean
+	constructionType: Boolean
+	roofType: Boolean
+	yearBuilt: Boolean
+	fireProofing: Boolean
+	denseUrbanEnvironment: Boolean
+	windDesignStandard: Boolean
+	wildfireInsuredValue: Boolean
+	wildfireDeductible: Boolean
+	wildfireDeductiblePerc: Boolean
+	wildfireBICoverageIncluded: Boolean
+	windInsuredValue: Boolean
+	windDeductible: Boolean
+	windDeductiblePerc: Boolean
+	windBICoverageIncluded: Boolean
+	floodInsuredValue: Boolean
+	floodDeductible: Boolean
+	floodDeductiblePerc: Boolean
+	floodBICoverageIncluded: Boolean
+	occupancyType: Boolean
+	contentsCost: Boolean
+	inventoryCost: Boolean
 }
 
 """
@@ -1328,1495 +2612,4532 @@ When `deleteByField` is provided then customizations for fields in `deleteByFiel
 When `deleteByField` is provided and is not null, if all fields are set to false or are not specified (null) then there will be no change to the building customizations.
 """
 input DeleteCustomBuildingValuesInput {
-    """
-    placeId identifies the place to delete custom building values for.
-    """
-    placeId: String!
+	"""
+	placeId identifies the place to delete custom building values for.
+	"""
+	placeId: String!
 
-    """
-    List of fields to clear building edits. When all are set to false then no changes will be made. When `deleteByField` is not provided or is null then all customizations will be deleted.
-    """
-    deleteByField: DeleteCustomBuildingValuesFieldsInput
+	"""
+	List of fields to clear building edits. When all are set to false then no changes will be made. When `deleteByField` is not provided or is null then all customizations will be deleted.
+	"""
+	deleteByField: DeleteCustomBuildingValuesFieldsInput
 }
 
 """
 The payload of deleting an existing building customization.
 """
 type DeleteCustomBuildingValuesPayload {
-    """
-    Indicates if the building customization was deleted successfully.
-    """
-    success: Boolean!
+	"""
+	Indicates if the building customization was deleted successfully.
+	"""
+	success: Boolean!
+}
+
+input DeletePortfolioFromParentInput {
+	"""
+	ID of the portfolio to be removed
+	"""
+	portfolioId: Int64!
+}
+
+input DeleteProjectAssetInput {
+	"""
+	The ID of the project to delete the asset from.
+	"""
+	projectId: Int64!
+
+	"""
+	Place ID of the asset to mark as deleted from the project.
+	"""
+	placeId: String!
 }
 
 """
 The payload of deleting a project.
 """
 input DeleteProjectInput {
-    """
-    The ID of the project to delete.
-    """
-    projectId: Int64!
+	"""
+	The ID of the project to delete.
+	"""
+	projectId: Int64!
+}
+
+type DeleteProjectJob implements ProjectJob {
+	"""
+	The ID of the project job. Note this ID as you'll need it to check the status of the job.
+	"""
+	projectJobId: Int64!
+
+	"""
+	The ID of the batch job.
+	"""
+	batchJobId: String!
+
+	"""
+	The name of the project job.
+	"""
+	projectJobName: String!
+
+	"""
+	Project Job type.
+	"""
+	projectJobType: ProjectJobType!
+
+	"""
+	The status of the project job.
+	"""
+	projectJobStatus: ProjectJobStatus!
+
+	"""
+	The error code of the project job.
+	"""
+	errorCode: String
+
+	"""
+	The error message of the project job.
+	"""
+	errorMessage: String
+
+	"""
+	The date when the job was created.
+	"""
+	createdOn: Date!
+
+	"""
+	The date when the job was updated.
+	"""
+	updatedOn: Date!
+
+	"""
+	The user who started the job.
+	"""
+	createdBy: User
+}
+
+"""
+The input for deleting existing portfolio staged custom building values.
+"""
+input DeleteProjectStagedCustomBuildingValuesInput {
+	"""
+	projectId identifies the project to delete custom building values for.
+	"""
+	projectId: Int64!
+
+	"""
+	placeId identifies the place to delete custom building values for.
+	"""
+	placeId: String!
+}
+
+input DeleteUserDataInput {
+	"""
+	The user's ID.
+	"""
+	userId: Int64!
+}
+
+input DeleteUserGroupStagedAdaptationsInput {
+	"""
+	The ID of the place to delete staged adaptations for.
+	"""
+	placeId: String!
+}
+
+"""
+A sub-portfolio in the subtree that has a dirty status, with its depth level.
+"""
+type DirtySubportfolio {
+	"""
+	The project ID of the dirty sub-portfolio.
+	"""
+	projectId: Int64!
+
+	"""
+	The depth level in the tree rooted at the queried portfolio.
+	Level 1 = direct child, level 2 = grandchild, etc.
+	"""
+	level: Int!
+
+	"""
+	The portfolio type of the dirty sub-portfolio.
+	"""
+	portfolioType: PortfolioType
+}
+
+type DroughtExposureStatistics {
+	"""
+	Socio-economic pathway of the prediction model.
+	"""
+	ssp: SSP!
+
+	"""
+	The relative year with current year being year 0.
+	"""
+	relativeYear: Int64!
+
+	"""
+	The number of weeks threshold.
+	"""
+	weeksThreshold: Int64!
+
+	"""
+	Maximum number of weeks of drought at return period 100 (1% likelihood) across the portfolio
+	"""
+	maxDroughtWeeks: Int64!
+
+	"""
+	Average number of weeks of drought at return period 100 (1% likelihood) across the portfolio
+	"""
+	avgDroughtWeeks: Int64!
+
+	"""
+	Number of assets exposed to drought for at least [weeksThreshold] weeks in the given scenario
+	"""
+	countDrought: Int64!
+
+	"""
+	Percentage of assets exposed to drought for at least [weeksThreshold] weeks in the given scenario
+	"""
+	pctDrought: Float!
+}
+
+type EconFactorDistribution {
+	"""
+	Socio-economic pathway of the prediction model.
+	"""
+	ssp: SSP!
+
+	"""
+	Holding Period
+	"""
+	relativeYear: Int!
+
+	"""
+	Lower bound of the Macroeconomic Factor score range.
+	"""
+	lowerbound: Int!
+
+	"""
+	Count of assets within the Macroeconomic Factor bound that include macroeconomic trends.
+	"""
+	econFactorCountClimate: Int
+
+	"""
+	Percentage of assets within the Macroeconomic Factor bound that include macroeconomic trends.
+	"""
+	econFactorPercClimate: Float
+
+	"""
+	Count of assets within the Macroeconomic Factor bound that include macroeconomic and market trends.
+	"""
+	econFactorCountClimateMarket: Int
+
+	"""
+	Percentage of assets within the Macroeconomic Factor bound that include macroeconomic and market trends.
+	"""
+	econFactorPercClimateMarket: Float
+
+	"""
+	The type of the locality.
+	"""
+	adminLevel: AdministrativeLevel!
+}
+
+input EconFactorDistributionFilter {
+	"""
+	The locality type id to filter by.
+	"""
+	adminLevel: AdministrativeLevel!
+}
+
+input EntDeleteViewedHistoryInput {
+	id: ID!
 }
 
 """
 The enterprise building type.
 """
 type EnterpriseBuilding {
-    """
-    The description of the asset
-    """
-    descriptor: String
+	"""
+	The description of the asset
+	"""
+	descriptor: String
 
-    """
-    Customer-defined unique identifier for the place (ex: building name, internal asset ID, etc.)
-    """
-    customId: String
+	"""
+	Customer-defined unique identifier for the place (ex: building name, internal asset ID, etc.)
+	"""
+	customId: String
 
-    """
-    Unique identifier for the location.
-    """
-    placeId: String!
+	"""
+	Unique identifier for the location.
+	"""
+	placeId: String!
 
-    """
-    The alias of the asset.
-    """
-    alias: String
+	"""
+	The alias of the asset.
+	"""
+	alias: String
 
-    """
-    The corresponding asset type ID for the asset.
-    """
-    assetTypeId: AssetTypeId
+	"""
+	The corresponding asset type ID for the asset.
+	"""
+	assetTypeId: AssetTypeId
 
-    """
-    Customer-provided longitude (at least 4 decimal point precision).
-    """
-    lng: Float
+	"""
+	Customer-provided longitude (at least 4 decimal point precision).
+	"""
+	lng: Float
 
-    """
-    Customer-provided latitude (at least 4 decimal point precision).
-    """
-    lat: Float
+	"""
+	Customer-provided latitude (at least 4 decimal point precision).
+	"""
+	lat: Float
 
-    """
-    Customer-provided address.
-    """
-    address: String
+	"""
+	Customer-provided address.
+	"""
+	address: String
 
-    """
-    Iso-3166-a3 country code
-    """
-    country: String
+	"""
+	Iso-3166-a3 country code
+	"""
+	country: String
 
-    """
-    Most recent valuation in US dollars. Required for some financial impact metrics
-    """
-    placeValuation: Int64
+	"""
+	Most recent valuation in US dollars. Required for some financial impact metrics
+	"""
+	placeValuation: Int64
 
-    """
-    Date of most recent valuation assessment. YYYY-MM-DD format
-    """
-    placeValueDate: Date
+	"""
+	Date of most recent valuation assessment. YYYY-MM-DD format
+	"""
+	placeValueDate: Date
 
-    """
-    Outstanding balance in US dollars
-    """
-    placeOutstandingBalance: Int64
+	"""
+	Outstanding balance in US dollars
+	"""
+	placeOutstandingBalance: Int64
 
-    """
-    Annual Net Operating Income. Required for some financial impact metrics
-    """
-    placeNOI: Int
+	"""
+	Annual Net Operating Income. Required for some financial impact metrics
+	"""
+	placeNOI: Int
 
-    """
-    The type of building.
-    """
-    placeType: LandUseType
+	"""
+	The type of building.
+	"""
+	placeType: LandUseType
 
-    """
-    The rebuild price per square foot for a structure (if it exists). Used to compute building damages
-    """
-    rebuildCostPerSf: Int64
+	"""
+	The rebuild price per square foot for a structure (if it exists). Used to compute building damages
+	"""
+	rebuildCostPerSf: Int64
 
-    """
-    Total square footage for the structure
-    """
-    buildingSf: Int
+	"""
+	Total square footage for the structure
+	"""
+	buildingSf: Int
 
-    """
-    Orientation of building. Options are N (default), NE, E, SE, S, SW, W, NW.
-    """
-    buildingDirection: CompassDirection
+	"""
+	Orientation of building. Options are N (default), NE, E, SE, S, SW, W, NW.
+	"""
+	buildingDirection: CompassDirection
 
-    """
-    The presence of defensible space around this property.
-    true = adequate defensible space exists, defined as a five foot buffer zone of cleared space around house AND <15% tree canopy within 50 ft. false (default) = defensible space does not exist.
-    """
-    defensibleSpace: Boolean
+	"""
+	The presence of defensible space around this property.
+	true = adequate defensible space exists, defined as a five foot buffer zone of cleared space around house AND <15% tree canopy within 50 ft. false (default) = defensible space does not exist.
+	"""
+	defensibleSpace: Boolean
 
-    """
-    Number of units in structure. Default value is 1.
-    """
-    units: Int
+	"""
+	Number of units in structure. Default value is 1.
+	"""
+	units: Int
 
-    """
-    Number of stories. Default value is 1.
-    """
-    stories: Int
+	"""
+	Number of stories. Default value is 1.
+	"""
+	stories: Int
 
-    """
-    The height associated with the first floor elevation for the building (in ft).
-    """
-    foundationHeightFt: Float
+	"""
+	The height associated with the first floor elevation for the building (in ft).
+	"""
+	foundationHeightFt: Float
 
-    """
-    The type of foundation. Used when exact foundation height isn't available.
-    """
-    foundationType: FoundationType
+	"""
+	The type of foundation. Used when exact foundation height isn't available.
+	"""
+	foundationType: FoundationType
 
-    """
-    Whether or not the property has a basement.
-    """
-    basement: Basement
+	"""
+	Whether or not the property has a basement.
+	"""
+	basement: Basement
 
-    """
-    The predominant construction material of the building
-    """
-    constructionType: ConstructionType
+	"""
+	The predominant construction material of the building
+	"""
+	constructionType: ConstructionType
 
-    """
-    The type of roofing material.
-    """
-    roofType: RoofType
+	"""
+	The type of roofing material.
+	"""
+	roofType: RoofType
 
-    """
-    Year of construction
-    """
-    yearBuilt: Int
+	"""
+	Year of construction
+	"""
+	yearBuilt: Int
 
-    """
-    Whether or not the property abides by the Fireproofing building code.
-    true = fire proofing measures exist for the home (such as fire-proofed windows, flame resistant exterior walls and ignition-resistant exterior doors). false (default) = does not exist.
-    """
-    fireProofing: Boolean
+	"""
+	Whether or not the property abides by the Fireproofing building code.
+	true = fire proofing measures exist for the home (such as fire-proofed windows, flame resistant exterior walls and ignition-resistant exterior doors). false (default) = does not exist.
+	"""
+	fireProofing: Boolean
 
-    """
-    Likelihood of damaging airborne missile in this vicinity. Based on built-up density at the Census tract level.
-    """
-    denseUrbanEnvironment: MissileEnvironment
+	"""
+	Likelihood of damaging airborne missile in this vicinity. Based on built-up density at the Census tract level.
+	"""
+	denseUrbanEnvironment: MissileEnvironment
 
-    """
-    The expected design standard of structures, based on ASCE 7-22 wind risk zones
-    """
-    windDesignStandard: WindDesignStandard
+	"""
+	The expected design standard of structures, based on ASCE 7-22 wind risk zones
+	"""
+	windDesignStandard: WindDesignStandard
 
-    """
-    Dollar value of wildfire insurance coverage sublimit (default: place valuation)
-    """
-    wildfireInsuredValue: Int64
+	"""
+	Dollar value of wildfire insurance coverage sublimit (default: place valuation)
+	"""
+	wildfireInsuredValue: Int64
 
-    """
-    Wildfire insurance deductible amount in dollars (default: $100,000)
-    """
-    wildfireDeductible: Int64
+	"""
+	Wildfire insurance deductible amount in dollars (default: $100,000)
+	"""
+	wildfireDeductible: Int64
 
-    """
-    Wildfire insurance deductible as percentage of insured value (if dollar value unavailable). 1.0 = 100%
-    """
-    wildfireDeductiblePerc: Float
+	"""
+	Wildfire insurance deductible as percentage of insured value (if dollar value unavailable). 1.0 = 100%
+	"""
+	wildfireDeductiblePerc: Float
 
-    """
-    true (default) = business interruption losses are covered under total wildfire insurance sublimit. false = business interruption losses are not covered
-    """
-    wildfireBICoverageIncluded: Boolean
+	"""
+	true (default) = business interruption losses are covered under total wildfire insurance sublimit. false = business interruption losses are not covered
+	"""
+	wildfireBICoverageIncluded: Boolean
 
-    """
-    Dollar value of wind insurance coverage sublimit (default: place valuation)
-    """
-    windInsuredValue: Int64
+	"""
+	Dollar value of wind insurance coverage sublimit (default: place valuation)
+	"""
+	windInsuredValue: Int64
 
-    """
-    Wind insurance deductible amount in dollars (default: $100,000)
-    """
-    windDeductible: Int64
+	"""
+	Wind insurance deductible amount in dollars (default: $100,000)
+	"""
+	windDeductible: Int64
 
-    """
-    Wind insurance deductible as percentage of insured value (if dollar value unavailable). 1.0 = 100%
-    """
-    windDeductiblePerc: Float
+	"""
+	Wind insurance deductible as percentage of insured value (if dollar value unavailable). 1.0 = 100%
+	"""
+	windDeductiblePerc: Float
 
-    """
-    true (default) = business interruption losses are covered under total wind insurance sublimit. false = business interruption losses are not covered
-    """
-    windBICoverageIncluded: Boolean
+	"""
+	true (default) = business interruption losses are covered under total wind insurance sublimit. false = business interruption losses are not covered
+	"""
+	windBICoverageIncluded: Boolean
 
-    """
-    Dollar value of flood insurance coverage sublimit (default: $0)
-    """
-    floodInsuredValue: Int64
+	"""
+	Dollar value of flood insurance coverage sublimit (default: $0)
+	"""
+	floodInsuredValue: Int64
 
-    """
-    Flood insurance deductible amount in dollars (default: $0)
-    """
-    floodDeductible: Int64
+	"""
+	Flood insurance deductible amount in dollars (default: $100,000)
+	"""
+	floodDeductible: Int64
 
-    """
-    Flood insurance deductible as percentage of insured value (if dollar value unavailable). 1.0 = 100%
-    """
-    floodDeductiblePerc: Float
+	"""
+	Flood insurance deductible as percentage of insured value (if dollar value unavailable). 1.0 = 100%
+	"""
+	floodDeductiblePerc: Float
 
-    """
-    true (default) = business interruption losses are covered under total flood insurance sublimit. false = business interruption losses are not covered
-    """
-    floodBICoverageIncluded: Boolean
+	"""
+	true (default) = business interruption losses are covered under total flood insurance sublimit. false = business interruption losses are not covered
+	"""
+	floodBICoverageIncluded: Boolean
+
+	"""
+	Occupancy type of the building.
+	"""
+	occupancyType: OccupancyType
+
+	"""
+	The replacement costs of the contents within the building.
+	"""
+	contentsCost: Int64
+
+	"""
+	The replacement costs of the inventory within the building.
+	"""
+	inventoryCost: Int64
+
+	"""
+	Value chain position of the company building. Applicable to staged building edits. Active value chain is determined by asset's `valuechain` node (see `ProjectAsset` type).
+	"""
+	valueChainPosition: ValueChainPosition
+
+	"""
+	Whether this asset is a material location in the value chain.
+	"""
+	materialLocation: Boolean
 }
 
 """
 The input to enterprise building edits.
 """
 input EnterpriseBuildingInput {
-    """
-    Identifies the place to update.
-    """
-    placeId: String!
+	"""
+	Identifies the place to update.
+	"""
+	placeId: String!
 
-    """
-    The alias of the asset.
-    """
-    alias: String
+	"""
+	The alias of the asset.
+	"""
+	alias: String
 
-    """
-    The corresponding asset type ID for the asset.
-    """
-    assetTypeId: AssetTypeId
+	"""
+	The corresponding asset type ID for the asset.
+	"""
+	assetTypeId: AssetTypeId
 
-    """
-    Customer-provided unique identifier for the place (ex: internal asset ID, etc.)
-    """
-    customId: String
+	"""
+	Customer-provided unique identifier for the place (ex: internal asset ID, etc.)
+	"""
+	customId: String
 
-    """
-    Most recent valuation in US dollars. Required for some financial impact metrics
-    """
-    placeValuation: Int64
+	"""
+	Most recent valuation in US dollars. Required for some financial impact metrics
+	"""
+	placeValuation: Int64
 
-    """
-    Outstanding balance in US dollars
-    """
-    placeOutstandingBalance: Int64
+	"""
+	Outstanding balance in US dollars
+	"""
+	placeOutstandingBalance: Int64
 
-    """
-    Annual Net Operating Income. Required for some financial impact metrics
-    """
-    placeNOI: Int
+	"""
+	Annual Net Operating Income. Required for some financial impact metrics
+	"""
+	placeNOI: Int
 
-    """
-    The type of building.
-    """
-    placeType: LandUseType
+	"""
+	The type of building.
+	"""
+	placeType: LandUseType
 
-    """
-    The rebuild price per square foot for a structure (if it exists). Used to compute building damages
-    """
-    rebuildCostPerSf: Int64
+	"""
+	The rebuild price per square foot for a structure (if it exists). Used to compute building damages
+	"""
+	rebuildCostPerSf: Int64
 
-    """
-    Total square footage for the structure
-    """
-    buildingSf: Int
+	"""
+	Total square footage for the structure
+	"""
+	buildingSf: Int
 
-    """
-    Orientation of building. Options are N (default), NE, E, SE, S, SW, W, NW.
-    """
-    buildingDirection: CompassDirection
+	"""
+	Orientation of building. Options are N (default), NE, E, SE, S, SW, W, NW.
+	"""
+	buildingDirection: CompassDirection
 
-    """
-    The presence of defensible space around this property.
-    true = adequate defensible space exists, defined as a five foot buffer zone of cleared space around house AND <15% tree canopy within 50 ft. false (default) = defensible space does not exist.
-    """
-    defensibleSpace: Boolean
+	"""
+	The presence of defensible space around this property.
+	true = adequate defensible space exists, defined as a five foot buffer zone of cleared space around house AND <15% tree canopy within 50 ft. false (default) = defensible space does not exist.
+	"""
+	defensibleSpace: Boolean
 
-    """
-    Number of units in structure.Three categories: 1 (default), 2–4 or 5 and up.
-    """
-    units: Int
+	"""
+	Number of units in structure.Three categories: 1 (default), 2–4 or 5 and up.
+	"""
+	units: Int
 
-    """
-    Number of stories. Default = 1
-    """
-    stories: Int
+	"""
+	Number of stories. Default = 1
+	"""
+	stories: Int
 
-    """
-    Foundation height (or first floor elevation) in ft
-    """
-    foundationHeightFt: Float
+	"""
+	Foundation height (or first floor elevation) in ft
+	"""
+	foundationHeightFt: Float
 
-    """
-    The type of foundation. Used when exact foundation height isn't available.
-    """
-    foundationType: FoundationType
+	"""
+	The type of foundation. Used when exact foundation height isn't available.
+	"""
+	foundationType: FoundationType
 
-    """
-    Whether or not the property has a basement.
-    """
-    basement: Basement
+	"""
+	Whether or not the property has a basement.
+	"""
+	basement: Basement
 
-    """
-    The predominant construction material of the building
-    """
-    constructionType: ConstructionType
+	"""
+	The predominant construction material of the building
+	"""
+	constructionType: ConstructionType
 
-    """
-    The type of roofing material.
-    """
-    roofType: RoofType
+	"""
+	The type of roofing material.
+	"""
+	roofType: RoofType
 
-    """
-    Year of construction
-    """
-    yearBuilt: Int
+	"""
+	Year of construction
+	"""
+	yearBuilt: Int
 
-    """
-    Whether or not the property abides by the Fireproofing building code.
-    true = fire proofing measures exist for the home (such as fire-proofed windows, flame resistant exterior walls and ignition-resistant exterior doors). false (default) = does not exist.
-    """
-    fireProofing: Boolean
+	"""
+	Whether or not the property abides by the Fireproofing building code.
+	true = fire proofing measures exist for the home (such as fire-proofed windows, flame resistant exterior walls and ignition-resistant exterior doors). false (default) = does not exist.
+	"""
+	fireProofing: Boolean
 
-    """
-    Likelihood of damaging airborne missile in this vicinity. Based on built-up density at the Census tract level.
-    """
-    denseUrbanEnvironment: MissileEnvironment
+	"""
+	Likelihood of damaging airborne missile in this vicinity. Based on built-up density at the Census tract level.
+	"""
+	denseUrbanEnvironment: MissileEnvironment
 
-    """
-    The expected design standard of structures, based on ASCE 7-22 wind risk zones
-    """
-    windDesignStandard: WindDesignStandard
+	"""
+	The expected design standard of structures, based on ASCE 7-22 wind risk zones
+	"""
+	windDesignStandard: WindDesignStandard
 
-    """
-    Dollar value of wildfire insurance coverage sublimit (default: place valuation)
-    """
-    wildfireInsuredValue: Int64
+	"""
+	Dollar value of wildfire insurance coverage sublimit (default: place valuation)
+	"""
+	wildfireInsuredValue: Int64
 
-    """
-    Wildfire insurance deductible amount in dollars (default: $100,000)
-    """
-    wildfireDeductible: Int64
+	"""
+	Wildfire insurance deductible amount in dollars (default: $100,000)
+	"""
+	wildfireDeductible: Int64
 
-    """
-    Wildfire insurance deductible as percentage of insured value (if dollar value unavailable). 1.0 = 100%
-    """
-    wildfireDeductiblePerc: Float
+	"""
+	Wildfire insurance deductible as percentage of insured value (if dollar value unavailable). 1.0 = 100%
+	"""
+	wildfireDeductiblePerc: Float
 
-    """
-    true (default) = business interruption losses are covered under total wildfire insurance sublimit. false = business interruption losses are not covered
-    """
-    wildfireBICoverageIncluded: Boolean
+	"""
+	true (default) = business interruption losses are covered under total wildfire insurance sublimit. false = business interruption losses are not covered
+	"""
+	wildfireBICoverageIncluded: Boolean
 
-    """
-    Dollar value of wind insurance coverage sublimit (default: place valuation)
-    """
-    windInsuredValue: Int64
+	"""
+	Dollar value of wind insurance coverage sublimit (default: place valuation)
+	"""
+	windInsuredValue: Int64
 
-    """
-    Wind insurance deductible amount in dollars (default: $100,000)
-    """
-    windDeductible: Int64
+	"""
+	Wind insurance deductible amount in dollars (default: $100,000)
+	"""
+	windDeductible: Int64
 
-    """
-    Wind insurance deductible as percentage of insured value (if dollar value unavailable). 1.0 = 100%
-    """
-    windDeductiblePerc: Float
+	"""
+	Wind insurance deductible as percentage of insured value (if dollar value unavailable). 1.0 = 100%
+	"""
+	windDeductiblePerc: Float
 
-    """
-    true (default) = business interruption losses are covered under total wind insurance sublimit. false = business interruption losses are not covered
-    """
-    windBICoverageIncluded: Boolean
+	"""
+	true (default) = business interruption losses are covered under total wind insurance sublimit. false = business interruption losses are not covered
+	"""
+	windBICoverageIncluded: Boolean
 
-    """
-    Dollar value of flood insurance coverage sublimit (default: $0)
-    """
-    floodInsuredValue: Int64
+	"""
+	Dollar value of flood insurance coverage sublimit (default: $0)
+	"""
+	floodInsuredValue: Int64
 
-    """
-    Flood insurance deductible amount in dollars (default: $0)
-    """
-    floodDeductible: Int64
+	"""
+	Flood insurance deductible amount in dollars (default: $100,000)
+	"""
+	floodDeductible: Int64
 
-    """
-    Flood insurance deductible as percentage of insured value (if dollar value unavailable). 1.0 = 100%
-    """
-    floodDeductiblePerc: Float
+	"""
+	Flood insurance deductible as percentage of insured value (if dollar value unavailable). 1.0 = 100%
+	"""
+	floodDeductiblePerc: Float
 
-    """
-    true (default) = business interruption losses are covered under total flood insurance sublimit. false = business interruption losses are not covered
-    """
-    floodBICoverageIncluded: Boolean
+	"""
+	true (default) = business interruption losses are covered under total flood insurance sublimit. false = business interruption losses are not covered
+	"""
+	floodBICoverageIncluded: Boolean
+
+	"""
+	Occupancy type of the building.
+	"""
+	occupancyType: OccupancyType
+
+	"""
+	The replacement costs of the contents within the building.
+	"""
+	contentsCost: Int64
+
+	"""
+	The replacement costs of the inventory within the building.
+	"""
+	inventoryCost: Int64
+
+	"""
+	Value chain position of the company building.
+	"""
+	valueChainPosition: ValueChainPosition
+
+	"""
+	Whether this asset is a material location in the value chain.
+	"""
+	materialLocation: Boolean
 }
 
 type EnterpriseGroup {
-    """
-    The name of the enterprise group.
-    """
-    name: String!
+	"""
+	The name of the enterprise group.
+	"""
+	name: String!
 
-    """
-    For enterprise user groups only. The maximum number of users that can be in the user group.
-    """
-    maxUsers: Int!
+	"""
+	For enterprise user groups only. The maximum number of users that can be in the user group.
+	"""
+	maxUsers: Int!
 
-    """
-    For enterprise user groups only. The maximum number of admins that can be in the user group.
-    """
-    maxAdmins: Int!
+	"""
+	For enterprise user groups only. The maximum number of admins that can be in the user group.
+	"""
+	maxAdmins: Int!
 
-    """
-    If set, the user group is in trial. Denotes the end date of the trial.
-    """
-    trialEnd: Date
+	"""
+	If set, the user group is in trial. Denotes the end date of the trial.
+	"""
+	trialEnd: Date
 
-    """
-    Workspaces the user group can access
-    """
-    workspaceAccess: [FirstStreetWorkspace]
+	"""
+	Workspaces the user group can access
+	"""
+	workspaceAccess: [FirstStreetWorkspace]
 
-    """
-    The default workspace for the user group
-    """
-    defaultWorkspace: FirstStreetWorkspace
+	"""
+	The default workspace for the user group
+	"""
+	defaultWorkspace: FirstStreetWorkspace
+
+	"""
+	The default subgroup for the user group
+	"""
+	userSubgroup: UserSubgroup
 }
 
 """
 An enterprise user is a member of an enterprise user group. Each enterprise user has either the member or the enterprise admin role.
 """
 type EnterpriseUser {
-    """
-    The user assigned to the enterprise user group.
-    """
-    user: User!
+	"""
+	The user assigned to the enterprise user group.
+	"""
+	user: User!
 
-    """
-    The enterprise group that the user belongs to.
-    """
-    enterpriseGroup: EnterpriseGroup!
+	"""
+	The enterprise group that the user belongs to.
+	"""
+	enterpriseGroup: EnterpriseGroup!
 
-    """
-    The role of the user in the user group.
-    """
-    enterpriseUserRole: EnterpriseUserRole!
+	"""
+	The role of the user in the user group.
+	"""
+	enterpriseUserRole: EnterpriseUserRole!
 }
 
 """
 Enterprise user role.
 """
 enum EnterpriseUserRole {
-    """
-    Administrators can manage users and assets.
-    """
-    ADMIN
+	"""
+	Administrators can manage users and assets.
+	"""
+	ADMIN
 
-    """
-    Users can manage projects and assets.
-    """
-    MEMBER
+	"""
+	Users can manage projects and assets.
+	"""
+	MEMBER
 
-    """
-    Users with read-only access to projects and assets.
-    """
-    VIEWER
+	"""
+	Users with read-only access to projects and assets.
+	"""
+	VIEWER
+}
+
+type EquityScoreData {
+	"""
+	The FS score for the Material Climate risk of a company
+	"""
+	score: Int64!
+
+	"""
+	Peril the data applies to. 2 = inland flood, 3 = hurricane, 4 = wildfire, 5 = overall.
+	"""
+	perilId: Int!
+
+	"""
+	Socio-economic pathway of the prediction model.
+	"""
+	ssp: SSP!
+
+	"""
+	The relative year with current year being year 0.
+	"""
+	relativeYear: Int64!
+
+	"""
+	Percentile value for estimates, one of: 10, 50, 90. 10th percentile estimate is low value, 90th percentile is high value, and 50th is mean. At this moment, only 50th percentile is available for this node.
+	"""
+	percentile: Int64!
 }
 
 """
 An export job is a job that exports the assets of a project.
 """
 type ExportJob implements ProjectJob {
-    """
-    The ID of the project job. Note this ID as you'll need it when importing assets from project job to project.
-    """
-    projectJobId: Int64!
+	"""
+	The ID of the project job. Note this ID as you'll need it when importing assets from project job to project.
+	"""
+	projectJobId: Int64!
 
-    """
-    The name of the project job.
-    """
-    projectJobName: String!
+	"""
+	The name of the project job.
+	"""
+	projectJobName: String!
 
-    """
-    Project Job type.
-    """
-    projectJobType: ProjectJobType!
+	"""
+	Project Job type.
+	"""
+	projectJobType: ProjectJobType!
 
-    """
-    The status of the project job.
-    """
-    projectJobStatus: ProjectJobStatus!
+	"""
+	The status of the project job.
+	"""
+	projectJobStatus: ProjectJobStatus!
 
-    """
-    The project this job is associated to.
-    """
-    project: Project
+	"""
+	The project this job is associated to.
+	"""
+	project: Project
 
-    """
-    Export job type.
-    """
-    exportJobType: ProjectExportJobType!
+	"""
+	Export job type.
+	"""
+	exportJobType: ProjectExportJobType!
 
-    """
-    The error code of the project job.
-    """
-    errorCode: String
+	"""
+	The error code of the project job.
+	"""
+	errorCode: String
 
-    """
-    The error message of the project job.
-    """
-    errorMessage: String
+	"""
+	The error message of the project job.
+	"""
+	errorMessage: String
 
-    """
-    The date when the job was created.
-    """
-    createdOn: Date!
+	"""
+	The date when the job was created.
+	"""
+	createdOn: Date!
 
-    """
-    The date when the job was updated.
-    """
-    updatedOn: Date!
+	"""
+	The date when the job was updated.
+	"""
+	updatedOn: Date!
 
-    """
-    The user who started the job.
-    """
-    createdBy: User
+	"""
+	The user who started the job.
+	"""
+	createdBy: User
 }
 
 """
 The corresponding text description that describes the `factor` score that is associated with the property.
 """
 enum FactorScale {
-    MINIMAL
-    MINOR
-    MODERATE
-    MAJOR
-    SEVERE
-    EXTREME
+	MINIMAL
+	MINOR
+	MODERATE
+	MAJOR
+	SEVERE
+	EXTREME
+}
+
+type FactorScore {
+	"""
+	Socio-economic pathway of the prediction model.
+	"""
+	ssp: SSP!
+
+	"""
+	Year, as relative to the current year.
+	"""
+	relativeYear: Int!
+
+	"""
+	The asset's peril's factor score value, a numeric integer from 1-10 (where 1 = minimal and 10 = extreme) based on peril risk to the asset.
+	"""
+	score: Int
+
+	"""
+	Text representation of the peril factor. Possible values are: minimal, minor, moderate, major, severe, extreme.
+	"""
+	scale: FactorScale
+}
+
+"""
+A feature flag attached to a user group.
+"""
+type Feature {
+	"""
+	The ID of the feature.
+	"""
+	featureId: Int!
+
+	"""
+	The name of the feature.
+	"""
+	name: String!
+
+	"""
+	Whether the feature is active.
+	"""
+	isActive: Boolean!
+}
+
+type FireExposureStatistics {
+	"""
+	Socio-economic pathway of the prediction model.
+	"""
+	ssp: SSP!
+
+	"""
+	The relative year with current year being year 0.
+	"""
+	relativeYear: Int64!
+
+	"""
+	The return period.
+	"""
+	returnPeriod: ReturnPeriod
+
+	"""
+	Maximum wildfire probability across a portfolio.
+	"""
+	maxWildfireProb: Float!
+
+	"""
+	Average wildfire probability across a portfolio.
+	"""
+	avgWildfireProb: Float!
+
+	"""
+	Number of assets exposed to wildfire probabilities above given probability (specified by return period)
+	"""
+	countFire: Int64!
+
+	"""
+	Percentage of assets exposed to wildfire probabilities above given probability (specified by return period)
+	"""
+	pctFire: Float!
 }
 
 enum FirstStreetWorkspace {
-    UNITED_STATES
-    GLOBAL
+	UNITED_STATES
+	GLOBAL
+}
+
+type FloodExposureStatistics {
+	"""
+	Socio-economic pathway of the prediction model.
+	"""
+	ssp: SSP!
+
+	"""
+	The relative year with current year being year 0.
+	"""
+	relativeYear: Int64!
+
+	"""
+	The return period.
+	"""
+	returnPeriod: ReturnPeriod
+
+	"""
+	The depth threshold in centimeters.
+	"""
+	floodDepthThresholdCm: Int64!
+
+	"""
+	Maximum mean depth in a portfolio at the given probability / SSP / Year
+	"""
+	maxDepthCm: Int64!
+
+	"""
+	Average mean depth in a portfolio at the given probability / SSP / Year
+	"""
+	avgDepthCm: Int64!
+
+	"""
+	Maximum lowpoint depth in a portfolio at the given probability / SSP / Year
+	"""
+	maxDepthLowpointCm: Int64!
+
+	"""
+	Average lowpoint depth in a portfolio at the given probability / SSP / Year
+	"""
+	avgDepthLowpointCm: Int64!
+
+	"""
+	Number of assets exposed to flooding above [floodDepthThresholdCm] depth in the given scenario
+	"""
+	countFlood: Int64!
+
+	"""
+	Percentage of assets exposed to flooding above [floodDepthThresholdCm] depth in the given scenario
+	"""
+	pctFlood: Float!
 }
 
 enum FoundationType {
-    CRAWL_OR_RAISED
-    CROSSED_WALLS
-    MASONRY
-    EARTH
-    MUD_SILL
-    STONE
-    CONCRETE_BLOCK
-    PILING
-    OTHER
-    PIERS
-    RETAINING_WALL
-    SLAB
-    FOOTING
-    WOOD
-    CONCRETE
-    BRICK
-    OPEN_PIERS
-    CLOSED_PIERS
+	CRAWL_OR_RAISED
+	CROSSED_WALLS
+	MASONRY
+	EARTH
+	MUD_SILL
+	STONE
+	CONCRETE_BLOCK
+	PILING
+	OTHER
+	PIERS
+	RETAINING_WALL
+	SLAB
+	FOOTING
+	WOOD
+	CONCRETE
+	BRICK
+	OPEN_PIERS
+	CLOSED_PIERS
+}
+
+"""
+Input for generating a link share.
+We can share either a project place (by providing projectId and placeId), a whole project (by providing only projectId), or an ePDP place (by providing only placeId).
+"""
+input GenerateLinkShareInput {
+	"""
+	Number of hours until the link expires. When 0 is provided the link will never expire.
+	"""
+	expirationInHours: Int!
+
+	"""
+	ID of the project being shared.
+	Required if placeId is not provided.
+	"""
+	projectId: Int64
+
+	"""
+	ID of the place being shared. Place ID can refer to a standalone ePDP, or a place in a project. Leave this field blank when sharing an entire project.
+	Required if projectId is not provided.
+	"""
+	placeId: String
+}
+
+type GenerateLinkSharePayload {
+	link: LinkShare!
 }
 
 type GenerateProjectExportDownloadLinkPayload {
-    """
-    The presigned download link for the exported project.
-    """
-    downloadLink: String!
+	"""
+	The presigned download link for the exported project.
+	"""
+	downloadLink: String!
 
-    """
-    Expiry Date of the presigned download link.
-    """
-    expiryDate: Date!
+	"""
+	Expiry Date of the presigned download link.
+	"""
+	expiryDate: Date!
 }
 
 type HazardDamage {
-    """
-    The peril exposed.
-    """
-    peril: String!
+	"""
+	The peril exposed.
+	"""
+	peril: String!
 
-    """
-    Socio-economic pathway of the prediction model.
-    """
-    ssp: SSP!
+	"""
+	Socio-economic pathway of the prediction model.
+	"""
+	ssp: SSP!
 
-    """
-    The relative year with current year being year 0.
-    """
-    relativeYear: Int64!
+	"""
+	The relative year with current year being year 0.
+	"""
+	relativeYear: Int64!
 
-    """
-    The return period (500, 100 years).
-    """
-    returnPeriod: ReturnPeriod
+	"""
+	The return period (500, 100 years).
+	"""
+	returnPeriod: ReturnPeriod
 
-    """
-    The number of assets with potential damages.
-    """
-    damagesCount: Int64!
+	"""
+	The number of assets with potential damages.
+	"""
+	damagesCount: Int64!
 
-    """
-    The percentage of assets with potential damages. 100% is 1.0.
-    """
-    damagesPercent: Float!
+	"""
+	The percentage of assets with potential damages. 100% is 1.0.
+	"""
+	damagesPercent: Float!
 }
 
 type HazardExposure {
-    """
-    The peril exposed.
-    """
-    peril: String!
+	"""
+	The peril exposed.
+	"""
+	peril: String!
 
-    """
-    Socio-economic pathway of the prediction model.
-    """
-    ssp: SSP!
+	"""
+	Socio-economic pathway of the prediction model.
+	"""
+	ssp: SSP!
 
-    """
-    The relative year with current year being year 0.
-    """
-    relativeYear: Int64!
+	"""
+	The relative year with current year being year 0.
+	"""
+	relativeYear: Int64!
 
-    """
-    The return period (500, 250, 100, 50, 20, 10, 5, or 2 years).
-    """
-    returnPeriod: ReturnPeriod
+	"""
+	The return period (500, 250, 100, 50, 20, 10, 5, or 2 years).
+	"""
+	returnPeriod: ReturnPeriod
 
-    """
-    The number of assets with this peril exposure.
-    """
-    exposedCount: Int64!
+	"""
+	The number of assets with this peril exposure.
+	"""
+	exposedCount: Int64!
 
-    """
-    The percentage of of assets with this peril exposure. 100% is 1.0.
-    """
-    exposedPercent: Float!
+	"""
+	The percentage of of assets with this peril exposure. 100% is 1.0.
+	"""
+	exposedPercent: Float!
+}
+
+type HazardExposureStatistics {
+	flood: [FloodExposureStatistics]
+	wind: [WindExposureStatistics]
+	fire: [FireExposureStatistics]
+	heat: [HeatExposureStatistics]
+	cold: [ColdExposureStatistics]
+	drought: [DroughtExposureStatistics]
+}
+
+type HeatExposureStatistics {
+	"""
+	Socio-economic pathway of the prediction model.
+	"""
+	ssp: SSP!
+
+	"""
+	The relative year with current year being year 0.
+	"""
+	relativeYear: Int64!
+
+	"""
+	The temperature threshold in degrees Fahrenheit.
+	"""
+	heatTempThresholdF: Int64!
+
+	"""
+	The number of days threshold.
+	"""
+	daysThreshold: Int64!
+
+	"""
+	Maximum number of days in a portfolio with heatindex at or above [heatTempThresholdF]
+	"""
+	maxHeatIndexDays: Int64!
+
+	"""
+	Average number of days in a portfolio with heatindex at or above [heatTempThresholdF]
+	"""
+	avgHeatIndexDays: Int64!
+
+	"""
+	Number of assets exposed to more than [daysThreshold] days above [heatTempThresholdF] heat index in the given scenario
+	"""
+	countHeat: Int64!
+
+	"""
+	Percentage of assets exposed to more than [daysThreshold] days above [heatTempThresholdF] heat index in the given scenario
+	"""
+	pctHeat: Float!
 }
 
 """
 The input to import staged assets from a project job into a project.
 """
 input ImportProjectAssetsInput {
-    """
-    The ID of the target project to import the staged assets into.
-    """
-    projectId: Int64!
+	"""
+	The ID of the target project to import the staged assets into.
+	"""
+	projectId: Int64!
 
-    """
-    The ID of the source project job that contains the staged assets to import from.
-    """
-    projectJobId: Int64!
+	"""
+	The ID of the source project job that contains the staged assets to import from.
+	"""
+	projectJobId: Int64!
+}
+
+"""
+Company industry information.
+"""
+type Industry {
+	"""
+	The ID of the industry.
+	"""
+	id: Int64!
+
+	"""
+	The name of the industry.
+	"""
+	name: String!
 }
 
 scalar Int64
 
 """
+Investment stage of a project. Used for root-level projects.
+"""
+enum InvestmentStage {
+	"""
+	Projects in the holding stage.
+	"""
+	HOLDING
+
+	"""
+	Projects in the acquisition stage.
+	"""
+	ACQUISITION
+}
+
+"""
 A issue is an additional status or information about an object.
 """
 type Issue {
-    """
-    The severity of the issue.
-    """
-    severity: Severity!
+	"""
+	The severity of the issue.
+	"""
+	severity: Severity!
 
-    """
-    The issue code.
-    """
-    code: String!
+	"""
+	The issue code.
+	"""
+	code: String!
 
-    """
-    The customer facing description.
-    """
-    description: String
+	"""
+	The customer facing description.
+	"""
+	description: String
 }
 
 enum LandUseType {
-    SINGLE_FAMILY_RESIDENTIAL
-    MULTIFAMILY
-    RETAIL
-    HOTEL
-    OFFICE
-    INDUSTRIAL
-    WAREHOUSE
-    AGRICULTURAL
-    VACANT
+	SINGLE_FAMILY_RESIDENTIAL
+	MULTIFAMILY
+	RETAIL
+	HOTEL
+	OFFICE
+	INDUSTRIAL
+	WAREHOUSE
+	AGRICULTURAL
+	VACANT
+}
+
+type LinearAssetAnalysisData {
+	linearHazardExposureStatistics: LinearHazardExposureStatistics
+}
+
+type LinearColdExposureStatistics {
+	"""
+	Socio-economic pathway of the prediction model.
+	"""
+	ssp: SSP!
+
+	"""
+	The relative year with current year being year 0.
+	"""
+	relativeYear: Int64!
+
+	"""
+	The temperature threshold in Fahrenheit.
+	"""
+	coldTempThresholdF: Int64!
+
+	"""
+	The number of days threshold.
+	"""
+	daysThreshold: Int64!
+
+	"""
+	Length in meters of linear assets in portfolio that are exposed to [daysThreshold] or more days at or below [coldTempThresholdF] wind chill in the given scenario
+	"""
+	coldLengthM: Float!
+
+	"""
+	Percent of total length (among linear assets) in portfolio that are exposed to [daysThreshold] or more days at or below [coldTempThresholdF] wind chill in the given scenario
+	"""
+	pctColdLengthM: Float!
+
+	"""
+	Count of segments that are exposed to [daysThreshold] or more days at or below [coldTempThresholdF] wind chill in the given scenario
+	"""
+	countCold: Int64!
+
+	"""
+	Percent of segments that are exposed to [daysThreshold] or more days at or below [coldTempThresholdF] wind chill in the given scenario
+	"""
+	pctCold: Float!
+}
+
+type LinearDroughtExposureStatistics {
+	"""
+	Socio-economic pathway of the prediction model.
+	"""
+	ssp: SSP!
+
+	"""
+	The relative year with current year being year 0.
+	"""
+	relativeYear: Int64!
+
+	"""
+	The number of weeks threshold.
+	"""
+	weeksThreshold: Int64!
+
+	"""
+	Length in meters of linear assets in portfolio exposed to more than [weeksThreshold] weeks of drought at return period 100 (1% likelihood)
+	"""
+	droughtLengthM: Float!
+
+	"""
+	Percent of total length (among linear assets) in portfolio that are exposed to drought for at least [weeksThreshold] weeks in the given scenario
+	"""
+	pctDroughtLengthM: Float!
+
+	"""
+	Count of segments that are exposed to drought for at least [weeksThreshold] weeks in the given scenario
+	"""
+	countDrought: Int64!
+
+	"""
+	Percent of segments that are exposed to drought for at least [weeksThreshold] weeks in the given scenario
+	"""
+	pctDrought: Float!
+}
+
+type LinearFireExposureStatistics {
+	"""
+	Socio-economic pathway of the prediction model.
+	"""
+	ssp: SSP!
+
+	"""
+	The relative year with current year being year 0.
+	"""
+	relativeYear: Int64!
+
+	"""
+	The return period.
+	"""
+	returnPeriod: ReturnPeriod
+
+	"""
+	Length in meters of linear assets in portfolio that are exposed to wildfire probabilities above given probability (specified by return period)
+	"""
+	fireLengthM: Float!
+
+	"""
+	Percent of total length (among linear assets) in portfolio that are exposed to wildfire probabilities above given probability (specified by return period)
+	"""
+	pctFireLengthM: Float!
+
+	"""
+	Count of segments that are exposed to wildfire probabilities above given probability (specified by return period)
+	"""
+	countFire: Int64!
+
+	"""
+	Percent of segments that are exposed to wildfire probabilities above given probability (specified by return period)
+	"""
+	pctFire: Float!
+}
+
+type LinearFloodExposureStatistics {
+	"""
+	Socio-economic pathway of the prediction model.
+	"""
+	ssp: SSP!
+
+	"""
+	The relative year with current year being year 0.
+	"""
+	relativeYear: Int64!
+
+	"""
+	The return period.
+	"""
+	returnPeriod: ReturnPeriod
+
+	"""
+	The depth threshold in centimeters.
+	"""
+	floodDepthThresholdCm: Int64!
+
+	"""
+	Length in meters of linear assets in portfolio that are exposed to flooding above [floodDepthThresholdCm] depth in the given scenario
+	"""
+	floodLengthM: Float!
+
+	"""
+	Percent of total length (among linear assets) in portfolio that are exposed to flooding above [floodDepthThresholdCm] depth in the given scenario
+	"""
+	pctFloodLengthM: Float!
+
+	"""
+	Count of segments that are exposed to flooding above [floodDepthThresholdCm] depth in the given scenario
+	"""
+	countFlood: Int64!
+
+	"""
+	Percent of segments that are exposed to flooding above [floodDepthThresholdCm] depth in the given scenario
+	"""
+	pctFlood: Float!
+}
+
+type LinearHazardExposureStatistics {
+	flood: [LinearFloodExposureStatistics]
+	wind: [LinearWindExposureStatistics]
+	fire: [LinearFireExposureStatistics]
+	heat: [LinearHeatExposureStatistics]
+	cold: [LinearColdExposureStatistics]
+	drought: [LinearDroughtExposureStatistics]
+}
+
+type LinearHeatExposureStatistics {
+	"""
+	Socio-economic pathway of the prediction model.
+	"""
+	ssp: SSP!
+
+	"""
+	The relative year with current year being year 0.
+	"""
+	relativeYear: Int64!
+
+	"""
+	The temperature threshold in Fahrenheit.
+	"""
+	heatTempThresholdF: Int64!
+
+	"""
+	The number of days threshold.
+	"""
+	daysThreshold: Int64!
+
+	"""
+	Length in meters of linear assets in portfolio that are exposed to more than [daysThreshold] days above [heatTempThresholdF] heat index in the given scenario
+	"""
+	heatLengthM: Float!
+
+	"""
+	Percent of total length (among linear assets) in portfolio that are exposed to more than [daysThreshold] days above [heatTempThresholdF] heat index in the given scenario
+	"""
+	pctHeatLengthM: Float!
+
+	"""
+	Count of segments that are exposed to more than [daysThreshold] days above [heatTempThresholdF] heat index in the given scenario
+	"""
+	countHeat: Int64!
+
+	"""
+	Percent of segments that are exposed to more than [daysThreshold] days above [heatTempThresholdF] heat index in the given scenario
+	"""
+	pctHeat: Float!
+}
+
+type LinearWindExposureStatistics {
+	"""
+	Socio-economic pathway of the prediction model.
+	"""
+	ssp: SSP!
+
+	"""
+	The relative year with current year being year 0.
+	"""
+	relativeYear: Int64!
+
+	"""
+	The return period.
+	"""
+	returnPeriod: ReturnPeriod
+
+	"""
+	The wind speed threshold in miles per hour.
+	"""
+	windSpeedThresholdMph: Int64!
+
+	"""
+	Length in meters of linear assets in portfolio that are exposed to speeds above [windSpeedThresholdMph] in the given scenario
+	"""
+	windLengthM: Float!
+
+	"""
+	Percent of total length (among linear assets) in portfolio that are exposed to speeds above [windSpeedThresholdMph] in the given scenario
+	"""
+	pctWindLengthM: Float!
+
+	"""
+	Count of segments that are exposed to 3-second wind gust speeds above [windSpeedThresholdMph] in the given scenario
+	"""
+	countWind: Int64!
+
+	"""
+	Percent of segments that are exposed to 3-second wind gust speeds above [windSpeedThresholdMph] in the given scenario
+	"""
+	pctWind: Float!
+}
+
+type LinkShare {
+	"""
+	ID of the link share. An alphanumeric token 24 characters in length.
+	"""
+	linkId: String!
+
+	"""
+	Returns whether the share is valid at the time of request.
+	"""
+	valid: Boolean!
+
+	"""
+	If a project place was shared, this will return the project it is a part of.
+	"""
+	project: Project
+
+	"""
+	Place ID being shared. It can be a standalone ePDP place, or a place in a portfolio. When portfolio is shared then it would be null.
+	"""
+	placeId: String
+
+	"""
+	Address for the shared place.
+	"""
+	address: String
+
+	"""
+	User who initiated the share.
+	"""
+	user: User!
+
+	"""
+	Date and time when the link is set to expire. Note: This is a distinct expiration from sessions. We may purge expired sessions, but records of
+	link shares will be kept until owner user group is deleted.
+	"""
+	expiration: Date!
+
+	"""
+	Date and time when the link share was created.
+	"""
+	createdAt: Date
+}
+
+"""
+An edge in the link shares connection.
+"""
+type LinkShareEdge {
+	"""
+	The link share at the end of the edge.
+	"""
+	node: LinkShare!
+
+	"""
+	Cursor is a string that can be used in subsequent request as value of a connection "after" argument, to request page starting after this item.
+	Example: *Y3Vyc29yOjEyNTI0MA==*
+	"""
+	cursor: String
+}
+
+"""
+Input for retrieving a link share.
+"""
+input LinkShareInput {
+	"""
+	ID of the link share to retrieve.
+	"""
+	linkId: String!
+}
+
+"""
+Payload for the linkShare query.
+"""
+type LinkSharePayload {
+	"""
+	The link share details. Null if the link share was not found.
+	"""
+	linkShare: LinkShare
+}
+
+"""
+A paginated connection of link shares.
+"""
+type LinkSharesConnection {
+	"""
+	The list of link share edges in this page.
+	"""
+	edges: [LinkShareEdge!]!
+
+	"""
+	Pagination information for this connection.
+	"""
+	pageInfo: PageInfo!
+
+	"""
+	The total number of link shares matching the query.
+	"""
+	totalCount: Int64
+}
+
+"""
+Sort order for link shares.
+"""
+enum LinkSharesSort {
+	"""
+	Sort by creation date in ascending order (oldest first).
+	"""
+	CREATED_AT_ASC
+
+	"""
+	Sort by creation date in descending order (newest first).
+	"""
+	CREATED_AT_DESC
+}
+
+"""
+Locality represents a specific geographic area, and can represent a country, country subdivision (like a state or a province), city, etc.
+"""
+type Locality {
+	"""
+	Unique ID for the Locality
+	"""
+	id: Int64!
+
+	"""
+	Two-digit country ISO code for the locality
+	"""
+	countryId: String!
+
+	"""
+	Name of the locality
+	"""
+	name: String!
+
+	"""
+	Admin level of the locality
+	"""
+	adminLevel: AdministrativeLevel
+
+	"""
+	Macroeconomic indicators for the locality
+	"""
+	macroeconomic(filterBy: AssetSortFilter): [LocalityMacroeconomicData!]!
+
+	"""
+	List of parent localities with their names and administrative levels.
+	"""
+	parentLocalities: [ParentLocality!]
+}
+
+input LocalityExportAssetsFilter {
+	"""
+	Cascading admin level to filter for
+	"""
+	adminLevel: AdministrativeLevel!
+
+	"""
+	Filter by admin level 0 locality Ids (countries)
+	"""
+	admin0Ids: [Int64!]
+
+	"""
+	Filter by admin level 1 locality Ids (e.g. States or Provinces)
+	"""
+	admin1Ids: [Int64!]
+
+	"""
+	Filter by admin level 2 locality Ids (counties)
+	"""
+	admin2Ids: [Int64!]
+
+	"""
+	Filter by admin level 8 locality Ids (metro areas)
+	"""
+	metroIds: [Int64!]
+}
+
+"""
+The iput parameter to a number of assets by contry code/admin level
+"""
+input LocalityExportInput {
+	"""
+	The file format to export the project in. (Default: CSV)
+	"""
+	fileFormat: ProjectExportFileFormat
+	localityFilters: [LocalityExportAssetsFilter]!
+}
+
+input LocalityFilter {
+	"""
+	The locality id to filter by.
+	"""
+	localityId: Int64!
+
+	"""
+	The locality type id to filter by.
+	"""
+	adminLevel: AdministrativeLevel!
+}
+
+type LocalityMacroeconomicData {
+	"""
+	Holding Period.
+	Years available: 0, 5, 10, 15, 20, 25, 30, 45, 60, 75.
+	"""
+	relativeYear: Int!
+
+	"""
+	Socioeconomic scenario (SSP)
+	"""
+	ssp: SSP!
+
+	"""
+	Macroeconomic Factor. Distilling climate-driven economic growth risks into an easy-to-digest score.
+	"""
+	econFactorClimate: Int @deprecated(reason: "This parameter is obsolete.")
+
+	"""
+	Text descriptor for Macroeconomic Factor. eg: Minimal, Minor, Moderate, Major, Severe, Extreme
+	"""
+	econFactorScaleClimate: FactorScale
+		@deprecated(reason: "This parameter is obsolete.")
+
+	"""
+	Macroeconomic Factor that includes market trends. Distilling climate-driven economic growth risks into an easy-to-digest score.
+	"""
+	econFactorClimateMarket: Int
+
+	"""
+	Text descriptor for Macroeconomic Factor that includes market trends. eg: Minimal, Minor, Moderate, Major, Severe, Extreme
+	"""
+	econFactorScaleClimateMarket: String
+
+	"""
+	Price of living: climate and market-driven change factor (%).
+	"""
+	priceOfLivingChangeFactorClimateMarket: Float
+
+	"""
+	Price of living: baseline value.
+	"""
+	priceOfLivingBaseline: Float
+
+	"""
+	Price of living: climate and market-driven change factor.
+	"""
+	priceOfLivingClimateMarketPctChange: Float
+
+	"""
+	Price of living: baseline value % change.
+	"""
+	priceOfLivingBaselinePctChange: Float
+
+	"""
+	Price of living: value given the climate and market effects
+	"""
+	priceOfLivingClimateMarket: Float
+
+	"""
+	Price of living: difference between the baseline % change factor and the climate-market % change factor
+	"""
+	priceOfLivingClimateMarketImpact: Float
+
+	"""
+	DTG: climate and market-driven change factor (%).
+	"""
+	dtgChangeFactorClimateMarket: Float
+
+	"""
+	DTG: baseline value.
+	"""
+	dtgBaseline: Float
+
+	"""
+	DTG: climate and market-driven change factor.
+	"""
+	dtgClimateMarketPctChange: Float
+
+	"""
+	DTG: baseline value % change.
+	"""
+	dtgBaselinePctChange: Float
+
+	"""
+	DTG: value given the climate and market effects
+	"""
+	dtgClimateMarket: Float
+
+	"""
+	DTG: difference between the baseline % change factor and the climate-market % change factor
+	"""
+	dtgClimateMarketImpact: Float
+
+	"""
+	GDP: climate-driven change factor (%).
+	"""
+	gdpChangeFactor: Float @deprecated(reason: "This parameter is obsolete.")
+
+	"""
+	GDP: climate and market-driven change factor (%).
+	"""
+	gdpChangeFactorClimateMarket: Float
+
+	"""
+	GDP: baseline value.
+	"""
+	gdpBaseline: Float
+
+	"""
+	GDP: climate and market-driven change factor.
+	"""
+	gdpClimateMarketPctChange: Float
+
+	"""
+	GDP: baseline value % change.
+	"""
+	gdpBaselinePctChange: Float
+
+	"""
+	GDP: value given the climate and market effects
+	"""
+	gdpClimateMarket: Float
+
+	"""
+	GDP: difference between the baseline % change factor and the climate-market % change factor
+	"""
+	gdpClimateMarketImpact: Float
+
+	"""
+	GDP per capita: climate-driven change factor (%).
+	"""
+	gdppcChangeFactor: Float @deprecated(reason: "This parameter is obsolete.")
+
+	"""
+	GDP per capita: climate and market-driven change factor (%).
+	"""
+	gdppcChangeFactorClimateMarket: Float
+
+	"""
+	GDP per capita: baseline value.
+	"""
+	gdppcBaseline: Float
+
+	"""
+	GDP per capita: climate and market-driven change factor.
+	"""
+	gdppcClimateMarketPctChange: Float
+
+	"""
+	GDP per capita: baseline value % change.
+	"""
+	gdppcBaselinePctChange: Float
+
+	"""
+	GDP per capita: value given the climate and market effects
+	"""
+	gdppcClimateMarket: Float
+
+	"""
+	GDP per capita: difference between the baseline % change factor and the climate-market % change factor
+	"""
+	gdppcClimateMarketImpact: Float
+
+	"""
+	Median age: climate-driven change (years).
+	Years available: 5,10,15,20,25,30,45,60,75.
+	"""
+	medianAgeChangeFactor: Float
+		@deprecated(reason: "This parameter is obsolete.")
+
+	"""
+	Median age: climate and market-driven change (years).
+	"""
+	medianAgeChangeFactorClimateMarket: Float
+
+	"""
+	Median age: baseline value.
+	"""
+	medianAgeBaseline: Float
+
+	"""
+	Median age: climate and market-driven change factor.
+	"""
+	medianAgeClimateMarketPctChange: Float
+
+	"""
+	Median age: baseline value % change.
+	"""
+	medianAgeBaselinePctChange: Float
+
+	"""
+	Median age: value given the climate and market effects
+	"""
+	medianAgeClimateMarket: Float
+
+	"""
+	Median age: difference between the baseline % change factor and the climate-market % change factor
+	"""
+	medianAgeClimateMarketImpact: Float
+
+	"""
+	Average gross income: climate and market-driven change factor (%).
+	"""
+	averageGrossIncomeChangeFactorClimateMarket: Float
+
+	"""
+	Average gross income: baseline value.
+	"""
+	averageGrossIncomeBaseline: Float
+
+	"""
+	Average gross income: climate and market-driven change factor.
+	"""
+	averageGrossIncomeClimateMarketPctChange: Float
+
+	"""
+	Average gross income: baseline value % change.
+	"""
+	averageGrossIncomeBaselinePctChange: Float
+
+	"""
+	Average gross income: value given the climate and market effects
+	"""
+	averageGrossIncomeClimateMarket: Float
+
+	"""
+	Average gross income: difference between the baseline % change factor and the climate-market % change factor
+	"""
+	averageGrossIncomeClimateMarketImpact: Float
+
+	"""
+	Native-born population percentage: climate-driven change (percentage points).
+	"""
+	nativeBornPctChangeFactor: Float
+		@deprecated(reason: "This parameter is obsolete.")
+
+	"""
+	Native-born population percentage: climate and market-driven change (percentage points).
+	"""
+	nativeBornPctChangeFactorClimateMarket: Float
+
+	"""
+	Native-born population percentage: baseline value.
+	"""
+	nativeBornPctBaseline: Float
+
+	"""
+	Native-born: climate and market-driven change factor.
+	"""
+	nativeBornClimateMarketPctChange: Float
+
+	"""
+	Native-born: baseline value % change.
+	"""
+	nativeBornBaselinePctChange: Float
+
+	"""
+	Native-born: value given the climate and market effects
+	"""
+	nativeBornClimateMarket: Float
+
+	"""
+	Native-born: difference between the baseline % change factor and the climate-market % change factor
+	"""
+	nativeBornClimateMarketImpact: Float
+
+	"""
+	Population: climate-driven change factor (%).
+	"""
+	populationChangeFactor: Float
+		@deprecated(reason: "This parameter is obsolete.")
+
+	"""
+	Population: climate and market-driven change factor (%).
+	"""
+	populationChangeFactorClimateMarket: Float
+
+	"""
+	Population: baseline value.
+	"""
+	populationBaseline: Float
+
+	"""
+	Population: climate and market-driven change factor.
+	"""
+	populationClimateMarketPctChange: Float
+
+	"""
+	Population: baseline value % change.
+	"""
+	populationBaselinePctChange: Float
+
+	"""
+	Population: value given the climate and market effects
+	"""
+	populationClimateMarket: Float
+
+	"""
+	Population: difference between the baseline % change factor and the climate-market % change factor
+	"""
+	populationClimateMarketImpact: Float
+
+	"""
+	Deprivation index: climate and market-driven change factor (%).
+	"""
+	deprivationIndexChangeFactorClimateMarket: Float
+
+	"""
+	Deprivation index: baseline value.
+	"""
+	deprivationIndexBaseline: Float
+
+	"""
+	Deprivation index: climate and market-driven change factor.
+	"""
+	deprivationIndexClimateMarketPctChange: Float
+
+	"""
+	Deprivation index: baseline value % change.
+	"""
+	deprivationIndexBaselinePctChange: Float
+
+	"""
+	Deprivation index: value given the climate and market effects
+	"""
+	deprivationIndexClimateMarket: Float
+
+	"""
+	Deprivation index: difference between the baseline % change factor and the climate-market % change factor
+	"""
+	deprivationIndexClimateMarketImpact: Float
+
+	"""
+	RPPI: climate-driven change factor (%).
+	"""
+	rppiChangeFactor: Float @deprecated(reason: "This parameter is obsolete.")
+
+	"""
+	RPPI: climate and market-driven change factor (%).
+	"""
+	rppiChangeFactorClimateMarket: Float
+
+	"""
+	RPPI: baseline value.
+	"""
+	rppiBaseline: Float
+
+	"""
+	RPPI: climate and market-driven change factor.
+	"""
+	rppiClimateMarketPctChange: Float
+
+	"""
+	RPPI: baseline value % change.
+	"""
+	rppiBaselinePctChange: Float
+
+	"""
+	RPPI: value given the climate and market effects
+	"""
+	rppiClimateMarket: Float
+
+	"""
+	RPPI: difference between the baseline % change factor and the climate-market % change factor
+	"""
+	rppiClimateMarketImpact: Float
+
+	"""
+	CPPI: climate-driven change factor (%).
+	"""
+	cppiChangeFactor: Float @deprecated(reason: "This parameter is obsolete.")
+
+	"""
+	CPPI: climate and market-driven change factor (%).
+	"""
+	cppiChangeFactorClimateMarket: Float
+
+	"""
+	CPPI: baseline value.
+	"""
+	cppiBaseline: Float
+
+	"""
+	CPPI: climate and market-driven change factor.
+	"""
+	cppiClimateMarketPctChange: Float
+
+	"""
+	CPPI: baseline value % change.
+	"""
+	cppiBaselinePctChange: Float
+
+	"""
+	CPPI: value given the climate and market effects
+	"""
+	cppiClimateMarket: Float
+
+	"""
+	CPPI: difference between the baseline % change factor and the climate-market % change factor
+	"""
+	cppiClimateMarketImpact: Float
+
+	"""
+	Unemployment: climate-driven change (percentage points).
+	"""
+	unemploymentChangeFactor: Float
+		@deprecated(reason: "This parameter is obsolete.")
+
+	"""
+	Unemployment: climate and market-driven change (percentage points).
+	"""
+	unemploymentChangeFactorClimateMarket: Float
+
+	"""
+	Unemployment: baseline value.
+	"""
+	unemploymentBaseline: Float
+
+	"""
+	Unemployment: climate and market-driven change factor.
+	"""
+	unemploymentClimateMarketPctChange: Float
+
+	"""
+	Unemployment: baseline value % change.
+	"""
+	unemploymentBaselinePctChange: Float
+
+	"""
+	Unemployment: value given the climate and market effects
+	"""
+	unemploymentClimateMarket: Float
+
+	"""
+	Unemployment: difference between the baseline % change factor and the climate-market % change factor
+	"""
+	unemploymentClimateMarketImpact: Float
+}
+
+type MacroeconomicData {
+	econFactorDistribution(
+		"""
+		Filter the array of data based on filterBy on locality
+		"""
+		filterBy: EconFactorDistributionFilter
+	): [EconFactorDistribution!]!
+}
+
+"""
+Information about a project's map tile file.
+"""
+type Map {
+	"""
+	Status of generating the map tile file.
+	"""
+	status: MapStatus
+	lastUpdated: Date
+
+	"""
+	The map tile file URL. This is a pre-signed S3 URL that will expire after one hour.
+	"""
+	url: String
+
+	"""
+	True when the portfolio map tile was generated successfully but one or more
+	descendants were absent from the merge (descendant tile FAILED, missing, or
+	could not be downloaded). The tile is still usable; treat as a warning, not
+	an error. A total tile-join failure is signaled separately via MapStatus.
+	Only populated for portfolio maps.
+	"""
+	hasMissingDescendants: Boolean
+}
+
+"""
+Project map tile file status
+"""
+enum MapStatus {
+	CREATING
+	ACTIVE
+	FAILED
 }
 
 enum MissileEnvironment {
-    LOW
-    HIGH
+	LOW
+	HIGH
+}
+
+"""
+Data to support the Adaptation module.
+"""
+type ModuleAdaptation {
+	status: AggregatedProjectModuleStatus
+	lastUpdated: Date
+	data: ProjectAdaptationData
+}
+
+"""
+Data to support the Adaptation Summary module.
+"""
+type ModuleAdaptationSummary {
+	status: AggregatedProjectModuleStatus
+	lastUpdated: Date
+	data: ProjectAdaptationSummaryData
 }
 
 """
 Data to support the Climate Exposure report.
 """
 type ModuleClimateExposure {
-    """
-    Climate Exposure data.
-    """
-    status: AggregatedProjectModuleStatus
-    lastUpdated: Date
-    data: ClimateExposureData
+	"""
+	Climate Exposure data.
+	"""
+	status: AggregatedProjectModuleStatus
+	lastUpdated: Date
+	data: ClimateExposureData
+}
+
+"""
+Data to support the Company Overview report.
+"""
+type ModuleCompanyOverview {
+	"""
+	CompanyOverview data.
+	"""
+	status: AggregatedProjectModuleStatus
+	lastUpdated: Date
+	data: CompanyOverviewData
+}
+
+"""
+Data to support the Linear Asset Analysis module
+"""
+type ModuleLinearAssetAnalysis {
+	"""
+	Linear asset analysis data.
+	"""
+	status: AggregatedProjectModuleStatus
+	lastUpdated: Date
+	data: LinearAssetAnalysisData
+}
+
+type ModuleLocality {
+	"""
+	Locality data.
+	"""
+	status: AggregatedProjectModuleStatus
+	lastUpdated: Date
+	data: ProjectLocalityData
+}
+
+"""
+Data to support Macroeconomic report.
+"""
+type ModuleMacroeconomic {
+	"""
+	Macroeconomic data.
+	"""
+	status: AggregatedProjectModuleStatus
+	lastUpdated: Date
+	data: MacroeconomicData
 }
 
 """
 Data to support project overview report.
 """
 type ModuleOverview {
-    """
-    Overview data.
-    """
-    status: AggregatedProjectModuleStatus
-    lastUpdated: Date
-    data: ModuleOverviewData
+	"""
+	Overview data.
+	"""
+	status: AggregatedProjectModuleStatus
+	lastUpdated: Date
+	data: ModuleOverviewData
 }
 
 type ModuleOverviewData {
-    """
-    Total rebuild cost
-    """
-    totalRebuildCost: Int64
+	"""
+	Total rebuild cost
+	"""
+	totalRebuildCost: Int64
 
-    """
-    Total asset valuation
-    """
-    totalAssetValuation: Int64
+	"""
+	Total asset valuation
+	"""
+	totalAssetValuation: Int64
 
-    """
-    Total asset net operating income
-    """
-    totalAssetNOI: Int64
+	"""
+	Total asset net operating income
+	"""
+	totalAssetNOI: Int64
 
-    """
-    Total asset outstanding balance
-    """
-    totalAssetOutstandingBalance: Int64
+	"""
+	Total asset outstanding balance
+	"""
+	totalAssetOutstandingBalance: Int64
 }
 
 """
 A module refresh job is a project job that generates module data from the data in the project.
 """
 type ModuleRefreshJob implements ProjectJob {
-    """
-    The ID of the project job. Note this ID as you'll need it when importing assets from project job to project.
-    """
-    projectJobId: Int64!
+	"""
+	The ID of the project job. Note this ID as you'll need it when importing assets from project job to project.
+	"""
+	projectJobId: Int64!
 
-    """
-    The project that this job is associated to.
-    """
-    project: Project
+	"""
+	The project that this job is associated to.
+	"""
+	project: Project
 
-    """
-    The name of the project job.
-    """
-    projectJobName: String!
+	"""
+	The name of the project job.
+	"""
+	projectJobName: String!
 
-    """
-    Project Job type.
-    """
-    projectJobType: ProjectJobType!
+	"""
+	Project Job type.
+	"""
+	projectJobType: ProjectJobType!
 
-    """
-    The status of the project job.
-    """
-    projectJobStatus: ProjectJobStatus!
+	"""
+	The status of the project job.
+	"""
+	projectJobStatus: ProjectJobStatus!
 
-    """
-    The error code of the project job.
-    """
-    errorCode: String
+	"""
+	The error code of the project job.
+	"""
+	errorCode: String
 
-    """
-    The error message of the project job.
-    """
-    errorMessage: String
+	"""
+	The error message of the project job.
+	"""
+	errorMessage: String
 
-    """
-    The date when the job was created.
-    """
-    createdOn: Date!
+	"""
+	The date when the job was created.
+	"""
+	createdOn: Date!
 
-    """
-    The date when the job was updated.
-    """
-    updatedOn: Date!
+	"""
+	The date when the job was updated.
+	"""
+	updatedOn: Date!
 
-    """
-    The user who started the job.
-    """
-    createdBy: User
+	"""
+	The user who started the job.
+	"""
+	createdBy: User
 }
 
 """
 Data to support Scenario Analysis report.
 """
 type ModuleScenarioAnalysis {
-    """
-    Scenario Analysis data.
-    """
-    status: AggregatedProjectModuleStatus
-    lastUpdated: Date
-    data: ScenarioAnalysisData
+	"""
+	Scenario Analysis data.
+	"""
+	status: AggregatedProjectModuleStatus
+	lastUpdated: Date
+	data: ScenarioAnalysisData
 }
 
 type Mutation {
-    """
-    Create a new project
-    """
-    createProject(input: CreateProjectInput!): CreateProjectPayload!
+	"""
+	Create a new project
+	"""
+	createProject(input: CreateProjectInput!): CreateProjectPayload!
 
-    """
-    Update project
-    """
-    updateProject(input: UpdateProjectInput!): Project!
+	"""
+	Update project
+	"""
+	updateProject(input: UpdateProjectInput!): Project!
 
-    """
-    Delete a project along with all of its associated resources
-    """
-    deleteProject(input: DeleteProjectInput!): RequestStatus!
+	"""
+	Update asset details for a project within a portfolio. Only valid for asset-type projects.
+	"""
+	updatePortfolioAssetDetails(
+		input: UpdatePortfolioAssetDetailsInput!
+	): Project!
 
-    """
-    Set project Status
-    """
-    setProjectStatus(projectId: Int64!, projectStatus: ProjectStatus!): Project!
+	"""
+	Delete a project along with all of its associated resources
+	"""
+	deleteProject(input: DeleteProjectInput!): RequestStatus!
+		@deprecated(reason: "Replaced by deleteProjectAsync")
 
-    """
-    Create a new project upload job with a link to upload a project
-    """
-    createProjectJobUploadLink(
-        input: CreateProjectJobUploadLinkInput!
-    ): CreateProjectJobUploadLinkPayload!
+	"""
+	Delete a project along with all of its associated resources
+	"""
+	deleteProjectAsync(input: DeleteProjectInput!): ProjectJob!
 
-    """
-    Export a project
-    """
-    createProjectExport(input: ProjectExportInput!): ExportJob!
+	"""
+	Set project Status
+	"""
+	setProjectStatus(projectId: Int64!, projectStatus: ProjectStatus!): Project!
 
-    """
-    Generate a download link for an exported project.
-    """
-    generateProjectExportDownloadLink(
-        projectJobId: Int64!
-    ): GenerateProjectExportDownloadLinkPayload!
+	"""
+	Create a new project upload job with a link to upload a project
+	"""
+	createProjectJobUploadLink(
+		input: CreateProjectJobUploadLinkInput!
+	): CreateProjectJobUploadLinkPayload!
 
-    """
-    Cancel an ongoing project export job.
-    """
-    cancelProjectExport(projectJobId: Int64!): ExportJob!
+	"""
+	Export a project
+	"""
+	createProjectExport(input: ProjectExportInput!): ExportJob!
 
-    """
-    Set upload job pendingImport flag.
-    """
-    setUploadJobPendingImport(
-        projectJobId: Int64!
-        pendingImport: Boolean!
-    ): UploadJob!
+	"""
+	Generate a download link for an exported project.
+	"""
+	generateProjectExportDownloadLink(
+		projectJobId: Int64!
+	): GenerateProjectExportDownloadLinkPayload!
 
-    """
-    Set a user groups custom building details for a specific place.
-    """
-    updateUserGroupCustomBuildingValues(
-        input: UpdateCustomEnterpriseBuildingValuesInput!
-    ): UpdateCustomBuildingValuesPayload!
+	"""
+	Cancel an ongoing project export job.
+	"""
+	cancelProjectExport(projectJobId: Int64!): ExportJob!
 
-    """
-    Delete a user groups custom building details for a specific place.
-    """
-    deleteUserGroupCustomBuildingValues(
-        input: DeleteCustomBuildingValuesInput
-    ): DeleteCustomBuildingValuesPayload!
+	"""
+	Set upload job pendingImport flag.
+	"""
+	setUploadJobPendingImport(
+		projectJobId: Int64!
+		pendingImport: Boolean!
+	): UploadJob!
 
-    """
-    Run project module refresh.
-    """
-    refreshProjectModule(
-        input: RefreshProjectModuleInput!
-    ): RefreshProjectModulePayload!
-    importProjectAssets(input: ImportProjectAssetsInput!): RequestStatus!
+	"""
+	Set user's portfolio custom building details for a specific place.
+	"""
+	updateProjectCustomBuildingValues(
+		input: UpdateProjectCustomBuildingValuesInput!
+	): UpdateProjectCustomBuildingValuesPayload!
+
+	"""
+	Set user group's custom building details for a specific place.
+	"""
+	updateUserGroupCustomBuildingValues(
+		input: UpdateCustomEnterpriseBuildingValuesInput!
+	): UpdateCustomBuildingValuesPayload!
+
+	"""
+	Delete a user group's custom building details for a specific place.
+	"""
+	deleteUserGroupCustomBuildingValues(
+		input: DeleteCustomBuildingValuesInput
+	): DeleteCustomBuildingValuesPayload!
+
+	"""
+	Set a user group's staged adaptations for a specific place.
+	"""
+	updateUserGroupStagedAdaptations(
+		input: UpdateUserGroupStagedAdaptationsInput!
+	): RequestStatus!
+
+	"""
+	Delete a user group's staged adaptations for a specific place.
+	"""
+	deleteUserGroupStagedAdaptations(
+		input: DeleteUserGroupStagedAdaptationsInput!
+	): RequestStatus!
+
+	"""
+	Set project-level staged adaptations for a specific place.
+	"""
+	updateProjectStagedAdaptations(
+		input: UpdateProjectStagedAdaptationsInput!
+	): RequestStatus!
+
+	"""
+	Update the planned status of specific project asset adaptations.
+	"""
+	updateProjectStagedAdaptationsPlan(
+		input: UpdateProjectStagedAdaptationsPlanInput!
+	): RequestStatus!
+
+	"""
+	Run project module refresh.
+	"""
+	refreshProjectModule(
+		input: RefreshProjectModuleInput!
+	): RefreshProjectModulePayload!
+	importProjectAssets(input: ImportProjectAssetsInput!): RequestStatus!
+
+	"""
+	Add a project asset by Place ID.
+	"""
+	addProjectAssetByPlaceID(input: AddProjectAssetInput!): RequestStatus!
+
+	"""
+	Delete a project asset by Place ID. The project asset will be marked for deletion and removed in the next project refresh.
+	"""
+	deleteProjectAssetByPlaceID(input: DeleteProjectAssetInput!): RequestStatus!
+
+	"""
+	Clone a project by the current user. Starts a background job to perform the clone.
+	"""
+	createProjectClone(input: ProjectCloneInput!): ProjectClonePayload!
+
+	"""
+	Export ALL locality econ data for a set of admin_levels(cascading) within a country code
+	"""
+	createLocalityMacroeconomicExport(input: LocalityExportInput!): ExportJob!
+
+	"""
+	Set a portfolio staged custom building details for a specific place.
+	"""
+	updateProjectStagedCustomBuildingValues(
+		input: UpdateProjectStagedCustomBuildingValuesInput!
+	): UpdateProjectStagedCustomBuildingValuesPayload!
+
+	"""
+	Delete a portfolio staged custom building details for a specific place.
+	"""
+	deleteProjectStagedCustomBuildingValues(
+		input: DeleteProjectStagedCustomBuildingValuesInput
+	): RequestStatus!
+
+	"""
+	Delete a user's personally identifiable information and group/subgroup associations.
+	"""
+	deleteUserData(input: DeleteUserDataInput!): RequestStatus!
+
+	"""
+	Generate a link share for a place on ePDP, an entire project, or a place in a project.
+	"""
+	generateLinkShare(input: GenerateLinkShareInput!): GenerateLinkSharePayload!
+	linkShare(linkId: String!): LinkShare
+	updateLinkShare(input: UpdateLinkShareInput!): UpdateLinkSharePayload!
+
+	"""
+	Delete a viewed history item from the list of viewed items for the current user.
+	"""
+	deleteViewedHistoryItem(input: EntDeleteViewedHistoryInput!): RequestStatus!
+
+	"""
+	Save a place or portfolio to the recently viewed items list for the current user.
+	"""
+	saveViewedHistoryItem(input: SaveViewHistoryInput!): SaveViewHistoryPayload!
+
+	"""
+	Assign a portfolio to a new parent portfolio.
+	"""
+	movePortfolio(input: UpdatePortfolioParentInput!): RequestStatus!
+
+	"""
+	Delete a portfolio that is the child of another portfolio.
+	"""
+	removePortfolioFromParent(
+		input: DeletePortfolioFromParentInput!
+	): RequestStatus!
+
+	"""
+	Assign a new parent to an REA.
+	"""
+	moveREAToNewParent(input: UpdateREAParentInput!): CreateProjectAssetPayload!
+
+	"""
+	Create a copy of an REA and assign it to a new parent.
+	"""
+	copyREAToNewParent(input: UpdateREAParentInput!): CreateProjectAssetPayload!
+
+	"""
+	Delete an REA that is the child of a portfolio.
+	"""
+	deleteREAFromParent(input: DeleteProjectAssetInput!): RequestStatus
+
+	"""
+	Create a copy of a portfolio and assign it to a new parent.
+	"""
+	copyPortfolioToNewParent(
+		input: CopyPortfolioToNewParentInput!
+	): CopyPortfolioToNewParentPayload!
+
+	"""
+	Move a portfolio asset to a new parent.
+	"""
+	movePortfolioAssetToNewParent(
+		input: UpdatePortfolioParentInput!
+	): RequestStatus!
+
+	"""
+	Creat a copy of a portfolio asset and assign it to a new parent.
+	"""
+	copyPortfolioAssetToNewParent(
+		input: UpdatePortfolioParentInput!
+	): ProjectClonePayload!
+
+	"""
+	Delete a portfolio asset from its portfolio.
+	"""
+	removePortfolioAssetFromParent(
+		input: DeletePortfolioFromParentInput!
+	): RequestStatus!
+
+	"""
+	Refresh a portfolio's data by triggering a refresh job.
+	The portfolio will appear in PROCESSING status while there is an unfinished PORTFOLIO_REFRESH job
+	"""
+	refreshPortfolio(input: RefreshPortfolioInput!): RequestStatus!
 }
 
 """
 Representation of the object and database ID
 """
 interface Node {
-    """
-    The unique identifier of the entity.
-    """
-    id: ID!
+	"""
+	The unique identifier of the entity.
+	"""
+	id: ID!
+}
+
+enum OccupancyType {
+	OWNER
+	OPERATOR
+	OWNER_OPERATOR
 }
 
 """
 PageInfo is returned for a connection. It contains pagination-related info, as well as connection edges (page entries).
 """
 type PageInfo {
-    """
-    hasPreviousPage informs if there is a previous page
-    """
-    hasPreviousPage: Boolean!
+	"""
+	hasPreviousPage informs if there is a previous page
+	"""
+	hasPreviousPage: Boolean!
 
-    """
-    hasNextPage informs if there is a next page
-    """
-    hasNextPage: Boolean!
+	"""
+	hasNextPage informs if there is a next page
+	"""
+	hasNextPage: Boolean!
 
-    """
-    startCursor refers to the cursor at start of the first page.
+	"""
+	startCursor refers to the cursor at start of the first page.
 
-    Example: *Y3Vyc29yOjEwMDU=*
-    """
-    startCursor: String
+	Example: *Y3Vyc29yOjEwMDU=*
+	"""
+	startCursor: String
 
-    """
-    endCursor refers to the the last item of the last page.
+	"""
+	endCursor refers to the the last item of the last page.
 
-    Example: *Y3Vyc29yOjEwMTI=*
-    """
-    endCursor: String
+	Example: *Y3Vyc29yOjEwMTI=*
+	"""
+	endCursor: String
+}
+
+"""
+Name and administrative level of a parent locality.
+"""
+type ParentLocality {
+	"""
+	Unique ID for the Locality
+	"""
+	id: Int64!
+
+	"""
+	The administrative level of the parent locality.
+	"""
+	adminLevel: AdministrativeLevel!
+
+	"""
+	The name of the parent locality.
+	"""
+	name: String!
+
+	"""
+	Two-digit country ISO code for the locality
+	"""
+	countryId: String!
+}
+
+type PerilBucketDistribution {
+	assetCount: Int
+	Minimal: BucketStat
+	Minor: BucketStat
+	Moderate: BucketStat
+	Major: BucketStat
+	Severe: BucketStat
+	Extreme: BucketStat
+	unweightedScore: Float
+	weightedScore: Float
+}
+
+"""
+A portfolio view combining the portfolio's own info with its paginated children.
+"""
+type Portfolio {
+	"""
+	Portfolio Id, which is also known as project id
+	"""
+	projectId: Int64
+
+	"""
+	Name of the portfolio
+	"""
+	name: String
+
+	"""
+	Portfolio type, can be either Mixed or Real Estate
+	"""
+	portfolioType: PortfolioType
+
+	"""
+	Parent portfolio Id
+	"""
+	parentProjectId: Int64
+
+	"""
+	Portfolio investment stage, either holding or acquisition
+	"""
+	investmentStage: InvestmentStage
+
+	"""
+	Current status of the portfolio, indicating whether the data is updated, in processing, or dirty
+	"""
+	portfolioStatus: PortfolioStatus
+
+	"""
+	Portfolio creation date
+	"""
+	createdAt: Date
+
+	"""
+	Number of assets including RealEstate, company, linear, or area assets
+	"""
+	assetCount: Int64
+
+	"""
+	Number of sub portfolios in the hierarchy
+	"""
+	portfolioCount: Int64
+
+	"""
+	Portfolio's subgroup id
+	"""
+	subGroupId: Int
+
+	"""
+	Filter contents available in the portfolio hierarchy
+	"""
+	portfolioFilterContent: PortfolioFilterContent
+
+	"""
+	The direct children of this portfolio (REAs, non-REA assets, and sub-portfolios).
+	"""
+	descendants(input: PortfolioContentsInput): PortfolioContentConnection!
+
+	"""
+	Dashboard scores for this portfolio, with optional filtering.
+	"""
+	portfolioDashboardScores(
+		filter: DashboardScoreFilter
+	): [PortfolioDashboardScore]
+
+	"""
+	Maps for the portfolio.
+	"""
+	map: PortfolioMap
+
+	"""
+	All sub-portfolios in the subtree that have a dirty status, with their tree level.
+	"""
+	dirtySubportfolios: [DirtySubportfolio!]
+}
+
+"""
+User-defined metadata for an asset-type project within a portfolio.
+"""
+type PortfolioAssetDetails {
+	typeId: AssetTypeId
+	operatingIncome: Int64
+	bookValue: Int64
+}
+
+"""
+Represents a content item within a portfolio - can be an REA, non-REA asset, or sub-portfolio.
+"""
+type PortfolioContent {
+	"""
+	The project ID. For REAs, this is the parent project ID. For non-REA assets and sub-portfolios, this is their own project ID.
+	"""
+	projectId: Int64!
+
+	"""
+	The place ID. Only set for REAs (real estate assets).
+	"""
+	placeId: String
+
+	"""
+	The name of the content item. For REAs, this is building.customid. For projects, this is company.name.
+	"""
+	name: String!
+
+	"""
+	The asset class. Values: "company", "linear", "area". Null for REPs and sub-portfolios.
+	"""
+	assetClass: ProjectAssetClass
+
+	"""
+	The portfolio type. Values: "Mixed", "RealEstate". Null for assets including REAs and company / linear / area assets.
+	"""
+	portfolioType: PortfolioType
+
+	"""
+	The parent project ID.
+	"""
+	parentProjectId: Int64
+
+	"""
+	The investment stage this content belongs to (Holding or Acquisition). Derived from the root project.
+	"""
+	investmentStage: InvestmentStage
+
+	"""
+	The portfolio status. Only set for sub-portfolios.
+	"""
+	portfolioStatus: PortfolioStatus
+
+	"""
+	The asset status. Only set for assets.
+	"""
+	assetStatus: AssetStatus
+
+	"""
+	The timestamp when the content was created.
+	"""
+	createdAt: Date!
+
+	"""
+	Total number of assets in the subtree (including self). For portfolios: REAs + company/linear/area in entire subtree. For leaf items: 1.
+	"""
+	assetCount: Int64
+
+	"""
+	Total number of sub-portfolios in the subtree. For portfolios: count of descendant portfolios. For leaf items: 0.
+	"""
+	portfolioCount: Int64
+
+	"""
+	User-defined asset metadata. Only populated for asset-type projects.
+	"""
+	portfolioAssetDetails: PortfolioAssetDetails
+
+	"""
+	Hazard peril scores for this item and its descendants.
+	Currently only `hazardFactorAggregate` and `hazardFactorAggregateWeighted` are implemented; other perils return null.
+	"""
+	perilScore: [PortfolioPerilScore!]
+}
+
+"""
+Connection type for paginated portfolio contents.
+"""
+type PortfolioContentConnection {
+	"""
+	The edges of the connection.
+	"""
+	edges: [PortfolioContentEdge!]!
+
+	"""
+	The page info of the connection.
+	"""
+	pageInfo: PageInfo!
+
+	"""
+	The total number of items in the connection.
+	"""
+	totalCount: Int64
+}
+
+"""
+Edge type for portfolio content pagination.
+"""
+type PortfolioContentEdge {
+	"""
+	The portfolio content node.
+	"""
+	node: PortfolioContent!
+
+	"""
+	The cursor of this edge.
+	"""
+	cursor: String
+}
+
+"""
+Sort order for portfolio contents.
+"""
+enum PortfolioContentSort {
+	CREATED_AT_ASC
+	CREATED_AT_DESC
+	ASSET_COUNT_ASC
+	ASSET_COUNT_DESC
+	PORTFOLIO_COUNT_ASC
+	PORTFOLIO_COUNT_DESC
+}
+
+"""
+The type of content in a portfolio.
+"""
+enum PortfolioContentType {
+	PORTFOLIO
+	ASSET
+}
+
+"""
+Shared input for querying portfolio contents (pagination, filtering, sorting).
+"""
+input PortfolioContentsInput {
+	"""
+	Number of records to return. A number between 0 and 200.
+	"""
+	first: Int = 200
+
+	"""
+	Cursor value past which records should be returned.
+	"""
+	after: String
+
+	"""
+	Filter by content type. Default (omitted): returns both portfolios and assets.
+	[PORTFOLIO]: returns only sub-portfolios.
+	[PORTFOLIO, ASSET]: returns both.
+	[ASSET] alone is not supported.
+	"""
+	types: [PortfolioContentType!]
+
+	"""
+	Sort order for the results.
+	"""
+	sort: PortfolioContentSort
+}
+
+type PortfolioDashboardScore {
+	ssp: SSP!
+	relativeYear: Int64!
+	hazardfactor: PerilBucketDistribution
+	floodfactor: PerilBucketDistribution
+	firefactor: PerilBucketDistribution
+	windfactor: PerilBucketDistribution
+	heatfactor: PerilBucketDistribution
+	coldfactor: PerilBucketDistribution
+	droughtfactor: PerilBucketDistribution
+	econfactor: PerilBucketDistribution
+}
+
+"""
+Portfolio contents available for portfolio level report filters
+"""
+type PortfolioFilterContent {
+	"""
+	Unique Portfolio IDs across the entire portfolio hierarchy
+	"""
+	portfolioIds: [Int64!]
+
+	"""
+	Unique Asset classes across the entire portfolio hierarchy
+	"""
+	assetClasses: [ProjectAssetClass!]
+
+	"""
+	Unique asset type IDs across the entire portfolio hierarchy
+	"""
+	assetTypeIds: [AssetTypeId!]
+
+	"""
+	Unique localities across the entire portfolio hierarchy
+	"""
+	localities: [Locality!]
+}
+
+input PortfolioInput {
+	"""
+	The ID of the portfolio project.
+	When provided, returns this portfolio's info and its children and `subGroupId` is ignored.
+	When omitted, returns root-level portfolios based on `subGroupId`.
+	"""
+	projectId: Int64
+
+	"""
+	Subgroup ID to scope root-level portfolios. Only used when `projectId` is omitted.
+	When provided (without `projectId`), returns root-level portfolios for this subgroup.
+	When omitted (without `projectId`), defaults to the user's default subgroup,
+	or the user's group if the user is not in any subgroup.
+	"""
+	subGroupId: Int
+}
+
+"""
+The merged map for a portfolio, containing all assets in the hierarchy.
+"""
+type PortfolioMap {
+	"""
+	The ID of the project.
+	"""
+	projectId: Int64!
+
+	"""
+	The merged portfolio map.
+	"""
+	portfolio: Map
+}
+
+"""
+A node in the portfolio path from root to a given project.
+"""
+type PortfolioPathNode {
+	"""
+	The project ID.
+	"""
+	id: Int64!
+
+	"""
+	The project name.
+	"""
+	name: String
+
+	"""
+	The portfolio status.
+	"""
+	portfolioStatus: PortfolioStatus
+
+	"""
+	The asset status.
+	"""
+	assetStatus: AssetStatus
+
+	"""
+	The portfolio type.
+	"""
+	portfolioType: PortfolioType
+}
+
+"""
+Aggregate peril scores (P75) across a portfolio per SSP and year.
+"""
+type PortfolioPerilScore {
+	ssp: SSP!
+	relativeYear: Int64!
+	floodFactorAggregate: Int
+	floodFactorAggregateWeighted: Int
+	fireFactorAggregate: Int
+	fireFactorAggregateWeighted: Int
+	windFactorAggregate: Int
+	windFactorAggregateWeighted: Int
+	heatFactorAggregate: Int
+	heatFactorAggregateWeighted: Int
+	coldFactorAggregate: Int
+	coldFactorAggregateWeighted: Int
+	droughtFactorAggregate: Int
+	droughtFactorAggregateWeighted: Int
+	hailFactorAggregate: Int
+	hailFactorAggregateWeighted: Int
+	airFactorAggregate: Int
+	airFactorAggregateWeighted: Int
+	hazardFactorAggregate: Int
+	hazardFactorAggregateWeighted: Int
+	econFactorAggregate: Int
+	econFactorAggregateWeighted: Int
+	insuranceFactorAggregate: Int
+	insuranceFactorAggregateWeighted: Int
+}
+
+"""
+Portfolio status of a project.
+"""
+enum PortfolioStatus {
+	"""
+	The portfolio is up to date.
+	"""
+	UPDATED
+
+	"""
+	The portfolio is dirty and needs recalculation.
+	"""
+	DIRTY
+
+	"""
+	The portfolio is currently processing.
+	"""
+	PROCESSING
+
+	"""
+	The latest job for this portfolio has failed.
+	"""
+	FAILED
+}
+
+"""
+Portfolio type for projects.
+"""
+enum PortfolioType {
+	"""
+	Real estate portfolio.
+	"""
+	REAL_ESTATE
+
+	"""
+	Mixed portfolio containing multiple asset types.
+	"""
+	MIXED
 }
 
 """
 The project type. A project is a collection of assets.
 """
 type Project {
-    """
-    The ID of the project.
-    """
-    id: Int64!
+	"""
+	The ID of the project.
+	"""
+	id: Int64!
 
-    """
-    The name of the project.
-    """
-    name: String
+	"""
+	The name of the project.
+	"""
+	name: String
 
-    """
-    The description of the project.
-    """
-    description: String
+	"""
+	The description of the project.
+	"""
+	description: String
 
-    """
-    The vintage version for the returned data. Vintage uniquely identifies the place and peril data version.
-    """
-    vintage: String!
+	"""
+	The vintage version for the returned data. Vintage uniquely identifies the place and peril data version.
+	"""
+	vintage: String! @deprecated(reason: "replaced by vintageId for consistency")
 
-    """
-    The enterprise group that owns this project
-    """
-    enterpriseGroup: EnterpriseGroup!
+	"""
+	The vintage version for the returned data. Vintage uniquely identifies the place and peril data version.
+	"""
+	vintageId: Int64
 
-    """
-    The status of the project.
-    """
-    status: ProjectStatus!
+	"""
+	Total assets in the project
+	"""
+	assetCount: Int64
 
-    """
-    The workspace of the project
-    """
-    workspace: FirstStreetWorkspace!
+	"""
+	The enterprise group that owns this project
+	"""
+	enterpriseGroup: EnterpriseGroup!
 
-    """
-    Module data for the project.
-    """
-    moduleData: ProjectModuleData!
+	"""
+	The status of the project.
+	"""
+	status: ProjectStatus!
 
-    """
-    The date when the project was created.
-    """
-    createdOn: Date
+	"""
+	The workspace of the project
+	"""
+	workspace: FirstStreetWorkspace!
 
-    """
-    The user who created the project.
-    """
-    createdBy: User
+	"""
+	Module data for the project.
+	"""
+	moduleData: ProjectModuleData!
 
-    """
-    The user who last edited the project.
-    """
-    updatedBy: User
+	"""
+	The default map for the project.
+	"""
+	maps: ProjectMaps
 
-    """
-    Indicates the number of project assets that have been updated since the last refresh. Max 100.
-    """
-    dirtyCount: Int!
+	"""
+	The date when the project was created.
+	"""
+	createdOn: Date
 
-    """
-    The list of assets in the project.
-    """
-    projectAssetConnection(
-        """
-        Number of records(edges) to return. A number between 0 and 100.
-        """
-        first: Int
+	"""
+	The user who created the project.
+	"""
+	createdBy: User
 
-        """
-        Cursor value of a record(edge) past which records should be returned. Cursor can be obtained from an earlier call. Cursor is a string between 10 and 32 characters long.
-        """
-        after: String
+	"""
+	The user who last edited the project.
+	"""
+	updatedBy: User
 
-        """
-        Number of prevous records(edges) to return. A number between 0 and 100.
-        """
-        last: Int
+	"""
+	Indicates the number of project assets that have been updated since the last refresh. Capped at 1001; values of 1001 indicate more than 1000 dirty assets.
+	"""
+	dirtyCount: Int!
 
-        """
-        Cursor value of a record(edge) before which records should be returned. Cursor can be obtained from an earlier call. Cursor is a string between 10 and 32 characters long.
-        """
-        before: String
+	"""
+	The list of assets in the project.
+	"""
+	projectAssetConnection(
+		"""
+		Number of records(edges) to return. A number between 0 and 100.
+		"""
+		first: Int
 
-        """
-        Filter the connection.
-        """
-        filter: ProjectAssetFilter
+		"""
+		Cursor value of a record(edge) past which records should be returned. Cursor can be obtained from an earlier call. Cursor is a string between 10 and 32 characters long.
+		"""
+		after: String
 
-        """
-        Sort order for the connection.
-        """
-        sort: AssetSort
-    ): ProjectAssetConnection
-    projectType: ProjectType!
-    company: Company
+		"""
+		Number of previous records(edges) to return. A number between 0 and 100.
+		"""
+		last: Int
+
+		"""
+		Cursor value of a record(edge) before which records should be returned. Cursor can be obtained from an earlier call. Cursor is a string between 10 and 32 characters long.
+		"""
+		before: String
+
+		"""
+		Filter the connection.
+		"""
+		filter: ProjectAssetFilter
+
+		"""
+		Sort order for the connection.
+		"""
+		sort: AssetSort
+	): ProjectAssetConnection
+	projectType: ProjectType!
+	company: Company
+
+	"""
+	The complex properties of the project, if applicable. This will only be populated for projects which represent
+	linear- or area-type assets.
+	"""
+	complexProperties: ComplexProperties
+	clonedFromProject: Project
+
+	"""
+	The parent project ID for hierarchy. NULL indicates root-level project.
+	"""
+	parentProjectId: Int64
+
+	"""
+	The portfolio type of the project.
+	"""
+	portfolioType: PortfolioType
+
+	"""
+	The portfolio status of the project.
+	"""
+	portfolioStatus: PortfolioStatus
+
+	"""
+	The asset class of the project such as COMPANY, LINEAR, AREA, or REAL_ESTATE.
+	"""
+	assetClass: ProjectAssetClass
+
+	"""
+	The timestamp when the project was created in MongoDB.
+	"""
+	createdAt: Date
+
+	"""
+	The centroid of the project's geometry. Only populated for linear and area projects.
+	"""
+	centroid: Coordinate
+
+	"""
+	AI-generated insights for this project.
+	"""
+	aiInsights: AIInsights
+
+	"""
+	User-defined asset metadata. Only populated for asset-class projects (assetClass != null).
+	"""
+	portfolioAssetDetails: PortfolioAssetDetails
+}
+
+type ProjectAdaptationData {
+	"""
+	Paginated list of per-asset adaptation results for this project.
+	"""
+	assetConnection(
+		"""
+		Number of records(edges) to return. A number between 0 and 100.
+		"""
+		first: Int
+
+		"""
+		Cursor value of a record(edge) past which records should be returned. Cursor can be obtained from an earlier call. Cursor is a string between 10 and 32 characters long.
+		"""
+		after: String
+
+		"""
+		Number of previous records(edges) to return. A number between 0 and 100.
+		"""
+		last: Int
+
+		"""
+		Cursor value of a record(edge) before which records should be returned. Cursor can be obtained from an earlier call. Cursor is a string between 10 and 32 characters long.
+		"""
+		before: String
+
+		"""
+		Filter the connection.
+		"""
+		filter: ProjectAssetAdaptationFilter!
+
+		"""
+		Sort order for the connection.
+		"""
+		sort: ProjectAssetAdaptationSort
+	): ProjectAssetAdaptationConnection
+}
+
+input ProjectAdaptationPlanItem {
+	"""
+	The place ID of the adaptation to update in the project adaptation plan.
+	"""
+	placeId: String!
+
+	"""
+	The adaptation type to update in the project adaptation plan.
+	"""
+	adaptation: AdaptationType!
+
+	"""
+	Flag to denote whether or not this adaptation is currently selected in the project adaptation plan.
+	"""
+	planned: Boolean!
+}
+
+type ProjectAdaptationSummaryData {
+	statistics(input: ProjectAssetAdaptationFilter!): [AdaptationSummaryData]
 }
 
 """
 A asset in a project.
 """
 type ProjectAsset {
-    """
-    The asset's place ID
-    """
-    placeId: String!
+	"""
+	The asset's place ID
+	"""
+	placeId: String!
 
-    """
-    The asset's climate exposure data
-    """
-    climateExposure: AssetClimateExposure
+	"""
+	The asset's building metadata derived from user input
+	"""
+	buildingMetadata: AssetBuildingMetadata
 
-    """
-    The asset's scenario analysis data
-    """
-    scenarioAnalysis: AssetScenarioAnalysis
+	"""
+	The asset's climate exposure data
+	"""
+	climateExposure: AssetClimateExposure
 
-    """
-    The project that this asset belongs to.
-    """
-    project: Project!
-    building: EnterpriseBuilding
+	"""
+	The asset's scenario analysis data
+	"""
+	scenarioAnalysis: AssetScenarioAnalysis
+
+	"""
+	The asset's locality data
+	"""
+	locality: AssetLocality
+
+	"""
+	The project that this asset belongs to.
+	"""
+	project: Project!
+	building: EnterpriseBuilding
+	stagedBuilding: EnterpriseBuilding
+	valuechain: AssetValueChain
+
+	"""
+	First Street Internal Use Only: If set to true, the project asset is newly added and needs a project refresh for statistics to be populated.
+	"""
+	newlyAdded: Boolean
+
+	"""
+	If set to true, the project asset is marked for deletion and will be removed in the next refresh.
+	"""
+	deleted: Boolean
+
+	"""
+	The timestamp when this asset was added to the project.
+	"""
+	createdAt: Date
+
+	"""
+	The geocode quality score of the asset from company data or geocoder
+	"""
+	geocodeQualityScore: Int
+}
+
+type ProjectAssetAdaptation {
+	"""
+	The asset's project ID.
+	"""
+	projectId: Int64!
+
+	"""
+	The asset's place ID.
+	"""
+	placeId: String!
+
+	"""
+	The address of the asset.
+	"""
+	address: String
+
+	"""
+	Socio-economic pathway of the prediction model.
+	"""
+	ssp: SSP!
+
+	"""
+	Hold Period of the asset in years.
+	"""
+	holdPeriod: Int!
+
+	"""
+	The relative year with current year being year 0.
+	"""
+	relativeYear: Int! @deprecated(reason: "Use holdPeriod instead.")
+
+	"""
+	Percentile value for estimates, one of: 10, 50, 90. 10th percentile estimate is low value, 90th percentile is high value, and 50th is mean.
+	"""
+	percentile: Int!
+
+	"""
+	The type of adaptation.
+	"""
+	type: AdaptationType!
+
+	"""
+	The display name of the adaptation.
+	"""
+	name: String!
+
+	"""
+	Flag to denote whether or not this adaptation is currently selected in the project adaptation plan.
+	"""
+	planned: Boolean!
+
+	"""
+	Flag to denote whether or not this is a user provided staged adaptation.
+	"""
+	edited: Boolean!
+
+	"""
+	The baseline loss on the asset.
+	"""
+	baselineLoss: Int64
+
+	"""
+	The adapted loss on the asset.
+	"""
+	adaptedLoss: Int64
+
+	"""
+	The savings on investment due to the adaptation.
+	"""
+	adaptationSOI: Int64
+
+	"""
+	The savings on investment as a percentage of the adaptation cost.
+	"""
+	adaptationSOIPct: Float
+
+	"""
+	The cumulative cost of the adaptation.
+	"""
+	cumulativeCost: Int64
+}
+
+type ProjectAssetAdaptationConnection {
+	"""
+	Returns a list of ProjectAssetAdaptationEdge. Each edge contains a cursor and the node.
+	"""
+	edges: [ProjectAssetAdaptationEdge!]!
+
+	"""
+	Pagination information in relation to current page.
+	"""
+	pageInfo: PageInfo!
+
+	"""
+	Total number of records for the connection.
+	"""
+	totalCount: Int64
+
+	"""
+	Total number of adaptations with the planned flag set to true.
+	"""
+	plannedCount: Int64
+}
+
+type ProjectAssetAdaptationEdge {
+	"""
+	Cursor is a string that can be used in subsequent request as value of a connection "after" argument, to request page starting after this item.
+	"""
+	cursor: String
+
+	"""
+	Contains one project asset adaptation data.
+	"""
+	node: ProjectAssetAdaptation!
+}
+
+input ProjectAssetAdaptationFilter {
+	"""
+	Socio-economic pathway of the prediction model.
+	"""
+	ssp: SSP!
+
+	"""
+	Hold Period of the asset in years.
+	"""
+	holdPeriod: Int
+
+	"""
+	The relative year with current year being year 0.
+	"""
+	relativeYear: Int
+
+	"""
+	Percentile value for estimates, one of: 10, 50, 90. 10th percentile estimate is low value, 90th percentile is high value, and 50th is mean.
+	"""
+	percentile: Int
+}
+
+enum ProjectAssetAdaptationSort {
+	BASELINE_LOSS_ASC
+	BASELINE_LOSS_DESC
+}
+
+"""
+Project asset class - categorizes the class of assets in a project.
+"""
+enum ProjectAssetClass {
+	"""
+	Real estate assets (properties).
+	"""
+	REAL_ESTATE
+
+	"""
+	Company assets.
+	"""
+	COMPANY
+
+	"""
+	Linear assets (pipelines, roads, etc.).
+	"""
+	LINEAR
+
+	"""
+	Area assets.
+	"""
+	AREA
 }
 
 """
 A list of project assets.
 """
 type ProjectAssetConnection {
-    """
-    Return a list of type that wraps edge type.
-    """
-    edges: [ProjectAssetEdge!]!
+	"""
+	Return a list of type that wraps edge type.
+	"""
+	edges: [ProjectAssetEdge!]!
 
-    """
-    Pagination information in relation to current page.
-    """
-    pageInfo: PageInfo!
+	"""
+	Pagination information in relation to current page.
+	"""
+	pageInfo: PageInfo!
 
-    """
-    Total number of records for the connection.
-    """
-    totalCount: Int64
+	"""
+	Total number of records for the connection.
+	"""
+	totalCount: Int64
+
+	"""
+	Number of assets with geocode quality score >= 95 (validated locations). Only applicable for company projects.
+	"""
+	validatedCount: Int64
+
+	"""
+	Number of assets with geocode quality score < 95 (non-validated locations). Only applicable for company projects.
+	"""
+	nonValidatedCount: Int64
 }
 
 """
 Represents an asset edge of the current project.
 """
 type ProjectAssetEdge {
-    """
-    Cursor is a string that can be used in subsequent request as value of a connection "after" argument, to request page starting after this item.
+	"""
+	Cursor is a string that can be used in subsequent request as value of a connection "after" argument, to request page starting after this item.
 
-    Example: *Y3Vyc29yOjEyNTI0MA==*
-    """
-    cursor: String
+	Example: *Y3Vyc29yOjEyNTI0MA==*
+	"""
+	cursor: String
 
-    """
-    Contains one page record data.
-    """
-    node: ProjectAsset!
+	"""
+	Contains one page record data.
+	"""
+	node: ProjectAsset!
 }
 
 """
 The input to filter project assets.
 """
 input ProjectAssetFilter {
-    """
-    Return the project asset that contains the given value in the address, alias or customer ID.
-    """
-    searchValue: String
+	"""
+	Return the project asset that contains the given value in the address, alias or customer ID.
+	"""
+	searchValue: String
 
-    """
-    filters for enterprise asset data, required for sorting. Sorting will not work if this filter is missing.
-    """
-    assetSortingFilter: AssetSortFilter
+	"""
+	filter for localities, only assets that belong to the specified locality will be returned. Does not currently work with asset sorting.
+	"""
+	localityFilter: LocalityFilter
+
+	"""
+	filters for localities, only assets that belong to the specified localities will be returned. Does not currently work with asset sorting.
+	"""
+	localityFilters: [LocalityFilter]
+
+	"""
+	filters for enterprise asset data, required for sorting. Sorting will not work if this filter is missing.
+	"""
+	assetSortingFilter: AssetSortFilter
+
+	"""
+	Filter by location validation status. When true, returns assets with geocodeQualityScore >= 95.
+	When false, returns assets with geocodeQualityScore < 95.
+	"""
+	locationValidated: Boolean
+
+	"""
+	Filter assets by valuechain position. Null value will skip the filter.
+	This should only be used for company portfolios, other types of portfolios won't return assets with this filter.
+	"""
+	valueChainPosition: [ValueChainPosition!]
+}
+
+input ProjectAutocompleteInput {
+	"""
+	Search by the company name or ticker.
+	"""
+	searchString: String!
+
+	"""
+	The maximum number of results to return. Default is 10.
+	"""
+	limit: Int
+}
+
+type ProjectAutocompletePayload {
+	results: [ProjectAutocompleteResult!]!
+}
+
+type ProjectAutocompleteResult {
+	projectId: Int64
+	display: String
+}
+
+"""
+Input type for the createProjectClone mutation.
+"""
+input ProjectCloneInput {
+	"""
+	The unique identifier of the project to be cloned.
+	"""
+	projectId: Int64!
+
+	"""
+	The new project name.
+	"""
+	projectName: String!
+
+	"""
+	The new project description.
+	"""
+	projectDescription: String
+
+	"""
+	Optional parent project ID. Defaults to Holding root project if not provided.
+	"""
+	parentProjectId: Int64
+}
+
+"""
+Job that clones one project into a new one.
+"""
+type ProjectCloneJob implements ProjectJob {
+	"""
+	The ID of the project job. Note this ID as you'll need it to check the status of the job.
+	"""
+	projectJobId: Int64!
+
+	"""
+	The name of the project job.
+	"""
+	projectJobName: String!
+
+	"""
+	Project Job type.
+	"""
+	projectJobType: ProjectJobType!
+
+	"""
+	The status of the project job.
+	"""
+	projectJobStatus: ProjectJobStatus!
+
+	"""
+	The error code of the project job.
+	"""
+	errorCode: String
+
+	"""
+	The error message of the project job.
+	"""
+	errorMessage: String
+
+	"""
+	The date when the job was created.
+	"""
+	createdOn: Date!
+
+	"""
+	The date when the job was updated.
+	"""
+	updatedOn: Date!
+
+	"""
+	The user who started the job.
+	"""
+	createdBy: User
+}
+
+type ProjectClonePayload {
+	"""
+	The unique identifier of the cloned project.
+	"""
+	projectId: Int64!
+
+	"""
+	The job created to clone the project.
+	"""
+	projectJob: ProjectJob!
+}
+
+"""
+The input to query building customization.
+"""
+input ProjectCustomBuildingValuesInput {
+	"""
+	Portfolio's project ID the building belongs to.
+	"""
+	projectId: Int64!
+
+	"""
+	Portfolio's place ID for the building.
+	"""
+	placeId: String!
+}
+
+"""
+The payload of getting an existing building customization.
+"""
+type ProjectCustomBuildingValuesPayload {
+	"""
+	The building customization details.
+	"""
+	building: EnterpriseBuilding
+}
+
+type ProjectEdge {
+	"""
+	The node of the edge.
+	"""
+	node: Project!
+
+	"""
+	The cursor of the edge.
+	"""
+	cursor: String
 }
 
 type ProjectEffects {
-    """
-    Peril the data appies to. 2 = inland flood, 3 = hurricane, 4 = wildfire, 5 = overall.
-    """
-    perilId: Int!
+	"""
+	Peril the data appies to. 2 = inland flood, 3 = hurricane, 4 = wildfire, 5 = overall.
+	"""
+	perilId: Int!
 
-    """
-    Socio-economic pathway of the prediction model.
-    """
-    ssp: SSP!
+	"""
+	Socio-economic pathway of the prediction model.
+	"""
+	ssp: SSP!
 
-    """
-    The relative year with current year being year 0.
-    """
-    relativeYear: Int64!
+	"""
+	The relative year with current year being year 0.
+	"""
+	relativeYear: Int64!
 
-    """
-    The return period (500, 100 years).
-    """
-    returnPeriod: ReturnPeriod!
+	"""
+	The return period (500, 100 years).
+	"""
+	returnPeriod: ReturnPeriod!
 
-    """
-    Percentile value for estimates, one of: 10, 50, 90. 10th percentile estimate is low value, 90th percentile is high value, and 50th is mean. At this moment, only 50th percentile is available for this node.
-    """
-    percentile: Int64!
+	"""
+	Percentile value for estimates, one of: 10, 50, 90. 10th percentile estimate is low value, 90th percentile is high value, and 50th is mean. At this moment, only 50th percentile is available for this node.
+	"""
+	percentile: Int64!
 
-    """
-    Gross direct damage (pre-insurance)
-    """
-    directGross: Int64!
+	"""
+	Gross direct damage (pre-insurance)
+	"""
+	directGross: Int64!
 
-    """
-    Gross direct damage (% of Total Prop Val)
-    """
-    directGrossPercent: Float!
+	"""
+	Gross direct damage (% of Total Prop Val)
+	"""
+	directGrossPercent: Float!
 
-    """
-    Net direct damage (post-insurance)
-    """
-    directNet: Int64!
+	"""
+	Net direct damage (post-insurance)
+	"""
+	directNet: Int64!
 
-    """
-    Net direct damage (% of Total Prop Val)
-    """
-    directNetPercent: Float!
+	"""
+	Net direct damage (% of Total Prop Val)
+	"""
+	directNetPercent: Float!
 
-    """
-    Event specific gross business interruption for a peril ($)
-    """
-    businessInterruptionGross: Int64!
+	"""
+	Event specific gross business interruption for a peril ($)
+	"""
+	businessInterruptionGross: Int64!
 
-    """
-    Event specific gross business interruption (% of Total Prop Val)
-    """
-    businessInterruptionGrossPercent: Float!
+	"""
+	Event specific gross business interruption (% of Total Prop Val)
+	"""
+	businessInterruptionGrossPercent: Float!
 
-    """
-    Event specific net business interruption for a peril ($)
-    """
-    businessInterruptionNet: Int64!
+	"""
+	Event specific net business interruption for a peril ($)
+	"""
+	businessInterruptionNet: Int64!
 
-    """
-    Event specific net business interruption (% of Total Prop Val)
-    """
-    businessInterruptionNetPercent: Float!
+	"""
+	Event specific net business interruption (% of Total Prop Val)
+	"""
+	businessInterruptionNetPercent: Float!
 
-    """
-    Event specific total cash gross direct damage and gross business interruption loss
-    """
-    cashGross: Int64!
+	"""
+	Event specific total cash gross direct damage and gross business interruption loss
+	"""
+	cashGross: Int64!
 
-    """
-    Event specific total cash gross direct damage and gross business interruption loss (% of Total Prop Val)
-    """
-    cashGrossPercent: Float!
+	"""
+	Event specific total cash gross direct damage and gross business interruption loss (% of Total Prop Val)
+	"""
+	cashGrossPercent: Float!
 
-    """
-    Event specific total cash net direct damage and net business interruption loss
-    """
-    cashNet: Int64!
+	"""
+	Event specific total cash net direct damage and net business interruption loss
+	"""
+	cashNet: Int64!
 
-    """
-    Event specific total cash net direct damage and net business interruption loss (% of Total Prop Val)
-    """
-    cashNetPercent: Float!
+	"""
+	Event specific total cash net direct damage and net business interruption loss (% of Total Prop Val)
+	"""
+	cashNetPercent: Float!
 }
 
 """
 Project export file format.
 """
 enum ProjectExportFileFormat {
-    """
-    Export the project in CSV format.
-    """
-    CSV
+	"""
+	Export the project in CSV format.
+	"""
+	CSV
 }
 
 """
 The iput parameter to export a project
 """
 input ProjectExportInput {
-    """
-    The ID of the project to export.
-    """
-    projectId: Int64!
+	"""
+	The ID of the project to export.
+	"""
+	projectId: Int64!
 
-    """
-    The file format to export the project in. (Default: CSV)
-    """
-    fileFormat: ProjectExportFileFormat
+	"""
+	The file format to export the project in. (Default: CSV)
+	"""
+	fileFormat: ProjectExportFileFormat
 
-    """
-    Export job type. Export all modules by default.
-    """
-    exportJobType: ProjectExportJobType
+	"""
+	Export job type. Export all modules by default.
+	"""
+	exportJobType: ProjectExportJobType
+
+	"""
+	Filters for what should be returned on the job.
+	"""
+	projectExportJobFilters: ProjectExportJobAssetFilters
+}
+
+"""
+Filtering for export jobs if applicable
+"""
+input ProjectExportJobAssetFilters {
+	"""
+	For the LOCALITY_MACROECONOMIC, which admin/locality level to target. Lower level ids cascade "down" to higher level ones
+	Internally, synonymous with locality0-3
+	"""
+	adminLevel: AdministrativeLevel
 }
 
 """
 Project export job type.
 """
 enum ProjectExportJobType {
-    """
-    Property Report Export
-    """
-    PROPERTY_REPORT
+	"""
+	Property Report Export
+	"""
+	PROPERTY_REPORT
 
-    """
-    Climate Exposure Export
-    """
-    CLIMATE_EXPOSURE
+	"""
+	Climate Exposure Export
+	"""
+	CLIMATE_EXPOSURE
 
-    """
-    Scenario Analysis Export
-    """
-    SCENARIO_ANALYSIS
+	"""
+	Scenario Analysis Export
+	"""
+	SCENARIO_ANALYSIS
 
-    """
-    All Modules Export
-    """
-    ALL_MODULES
+	"""
+	All Modules Export
+	"""
+	ALL_MODULES
+
+	"""
+	Equity Overview Export
+	"""
+	EQUITY_OVERVIEW
+
+	"""
+	Locality Macroeconomic export
+	"""
+	LOCALITY_MACROECONOMIC
+
+	"""
+	Full Portfolio Export
+	"""
+	FULL_PORTFOLIO
+}
+
+input ProjectFilter {
+	"""
+	Filter to only show projects cloned from a company.
+	"""
+	companyOnly: Boolean
+
+	"""
+	Only return projects cloned from some company or portfolio.
+	"""
+	clonedOnly: Boolean
 }
 
 """
 A project job is a job that interacts with the assets of a project.
 """
 interface ProjectJob {
-    """
-    The ID of the project job. Note this ID as you'll need it when importing assets from project job to project.
-    """
-    projectJobId: Int64!
+	"""
+	The ID of the project job. Note this ID as you'll need it when importing assets from project job to project.
+	"""
+	projectJobId: Int64!
 
-    """
-    The name of the project job.
-    """
-    projectJobName: String!
+	"""
+	The name of the project job.
+	"""
+	projectJobName: String!
 
-    """
-    Project Job type.
-    """
-    projectJobType: ProjectJobType!
+	"""
+	Project Job type.
+	"""
+	projectJobType: ProjectJobType!
 
-    """
-    The status of the project job.
-    """
-    projectJobStatus: ProjectJobStatus!
+	"""
+	The status of the project job.
+	"""
+	projectJobStatus: ProjectJobStatus!
 
-    """
-    The error code of the project job.
-    """
-    errorCode: String
+	"""
+	The error code of the project job.
+	"""
+	errorCode: String
 
-    """
-    The error message of the project job.
-    """
-    errorMessage: String
+	"""
+	The error message of the project job.
+	"""
+	errorMessage: String
 
-    """
-    The date when the job was created.
-    """
-    createdOn: Date!
+	"""
+	The date when the job was created.
+	"""
+	createdOn: Date!
 
-    """
-    The date when the job was updated.
-    """
-    updatedOn: Date!
+	"""
+	The date when the job was updated.
+	"""
+	updatedOn: Date!
 
-    """
-    The user who started the job.
-    """
-    createdBy: User
+	"""
+	The user who started the job.
+	"""
+	createdBy: User
 }
 
 type ProjectJobEdge {
-    """
-    The project job node of the edge.
-    """
-    node: ProjectJob!
+	"""
+	The project job node of the edge.
+	"""
+	node: ProjectJob!
 
-    """
-    The cursor of the project job edge.
-    """
-    cursor: String!
+	"""
+	The cursor of the project job edge.
+	"""
+	cursor: String!
 }
 
 """
 The input to a project job.
 """
 input ProjectJobFilter {
-    """
-    Filter on specific project job statuses.
-    """
-    status: [ProjectJobStatusEnum]
+	"""
+	Filter on specific project job statuses.
+	"""
+	status: [ProjectJobStatusEnum]
 
-    """
-    Filter on specific project job types.
-    """
-    jobType: [ProjectJobType]
+	"""
+	Filter on specific project job types.
+	"""
+	jobType: [ProjectJobType]
 
-    """
-    Filter on the user who created the project job by user ID.
-    """
-    createdBy: Int64
+	"""
+	Filter on the user who created the project job by user ID.
+	"""
+	createdBy: Int64
 
-    """
-    For Upload Jobs: Filter on whether there are pending staged assets to be imported into the project.
-    """
-    pendingImport: Boolean
+	"""
+	For Upload Jobs: Filter on whether there are pending staged assets to be imported into the project.
+	"""
+	pendingImport: Boolean
 
-    """
-    Filter on specific export job types.
-    """
-    exportJobType: ProjectExportJobType
+	"""
+	Filter on specific export job types.
+	"""
+	exportJobType: ProjectExportJobType
 }
 
 """
 Project job status type.
 """
 type ProjectJobStatus {
-    """
-    The name of the project job status.
-    """
-    name: ProjectJobStatusEnum!
+	"""
+	The name of the project job status.
+	"""
+	name: ProjectJobStatusEnum!
 }
 
 """
 Status enum of a project job.
 """
 enum ProjectJobStatusEnum {
-    """
-    The job is submitted to the Enterprise service.
-    """
-    SUBMITTED
+	"""
+	The job is submitted to the Enterprise service.
+	"""
+	SUBMITTED
 
-    """
-    The job is running in the Enterprise service.
-    """
-    RUNNING
+	"""
+	The job is running in the Enterprise service.
+	"""
+	RUNNING
 
-    """
-    The job is completed. Assets are staged and ready to be imported into a project.
-    """
-    COMPLETED
+	"""
+	The job is completed. Assets are staged and ready to be imported into a project.
+	"""
+	COMPLETED
 
-    """
-    The job has failed.
-    """
-    FAILED
+	"""
+	The job has failed.
+	"""
+	FAILED
 
-    """
-    The job is canceled.
-    """
-    CANCELED
+	"""
+	The job is canceled.
+	"""
+	CANCELED
 }
 
 """
 The category of the project
 """
 enum ProjectJobType {
-    PROJECT_UPLOAD
-    MODULES_REFRESH
-    PROJECT_EXPORT
+	PROJECT_UPLOAD
+	MODULES_REFRESH
+	PROJECT_EXPORT
+	PROJECT_CLONE
+	LOCALITY_EXPORT
+	PROJECT_DELETE
+	PORTFOLIO_REFRESH
 }
 
 type ProjectJobsConnection {
-    """
-    The total number of project jobs in the connection.
-    """
-    totalCount: Int64!
+	"""
+	The total number of project jobs in the connection.
+	"""
+	totalCount: Int64!
 
-    """
-    The edges of the project jobs connection.
-    """
-    edges: [ProjectJobEdge!]!
+	"""
+	The edges of the project jobs connection.
+	"""
+	edges: [ProjectJobEdge!]!
 
-    """
-    The page info of the project jobs connection.
-    """
-    pageInfo: PageInfo!
+	"""
+	The page info of the project jobs connection.
+	"""
+	pageInfo: PageInfo!
 }
 
 enum ProjectJobsSort {
-    LAST_UPDATED_ASC
-    LAST_UPDATED_DESC
+	LAST_UPDATED_ASC
+	LAST_UPDATED_DESC
+}
+
+"""
+The input to get all project's localities.
+"""
+input ProjectLocalitiesInput {
+	"""
+	The ID of the type of locality.
+	"""
+	adminLevel: AdministrativeLevel!
+
+	"""
+	The ID of the locality to filter by.
+	For country level (localityTypeId=0) `parentLocalityId` value is ignored, all project's countries will be returned regarless of the value.
+	For other levels `parentLocalityId` value is required
+	"""
+	parentLocalityId: Int64
+
+	"""
+	The ID of the project to get localities for.
+	"""
+	projectId: Int64!
+}
+
+"""
+The payload for getting all project's localities.
+"""
+type ProjectLocalitiesPayload {
+	"""
+	The list of localities for the project filtered based on the input.
+	"""
+	localities: [Locality]
+}
+
+type ProjectLocalityData {
+	exposureConnection(
+		"""
+		Number of records(edges) to return. A number between 0 and 100.
+		"""
+		first: Int
+
+		"""
+		Cursor value of a record(edge) past which records should be returned. Cursor can be obtained from an earlier call. Cursor is a string between 10 and 32 characters long.
+		"""
+		after: String
+
+		"""
+		Number of previous records(edges) to return. A number between 0 and 100.
+		"""
+		last: Int
+
+		"""
+		Cursor value of a record(edge) before which records should be returned. Cursor can be obtained from an earlier call. Cursor is a string between 10 and 32 characters long.
+		"""
+		before: String
+
+		"""
+		Filter the connection.
+		"""
+		filter: ProjectLocalityExposureFilter!
+
+		"""
+		Sort order for the connection.
+		"""
+		sort: ProjectLocalityExposureSort
+	): ProjectLocalityExposureConnection
+}
+
+type ProjectLocalityExposure {
+	"""
+	Locality information for the regional exposure record.
+	"""
+	locality: Locality!
+
+	"""
+	Socio-economic pathway for this locality exposure record.
+	"""
+	ssp: SSP!
+
+	"""
+	Relative year for this locality exposure record (0 = current year).
+	"""
+	relativeYear: Int!
+
+	"""
+	Total number of properties in the locality at risk.
+	"""
+	totalCount: Int64!
+
+	"""
+	Number of properties in the locality at risk for flood.
+	"""
+	floodCount: Int64
+
+	"""
+	Percent of properties in the locality at risk for flood. 100% is 1.0.
+	"""
+	floodPct: Float
+
+	"""
+	Number of properties in the locality at risk for wildfire.
+	"""
+	wildfireCount: Int64
+
+	"""
+	Percent of properties in the locality at risk for wildfire. 100% is 1.0.
+	"""
+	wildfirePct: Float
+
+	"""
+	Number of properties in the locality at risk for heat.
+	"""
+	heatCount: Int64
+
+	"""
+	Percent of properties in the locality at risk for heat. 100% is 1.0.
+	"""
+	heatPct: Float
+
+	"""
+	Number of properties in the locality at risk for cold.
+	"""
+	coldCount: Int64
+
+	"""
+	Percent of properties in the locality at risk for cold. 100% is 1.0.
+	"""
+	coldPct: Float
+
+	"""
+	Number of properties in the locality at risk for drought.
+	"""
+	droughtCount: Int64
+
+	"""
+	Percent of properties in the locality at risk for drought. 100% is 1.0.
+	"""
+	droughtPct: Float
+
+	"""
+	Number of properties in the locality at risk for wind.
+	"""
+	windCount: Int64
+
+	"""
+	Percent of properties in the locality at risk for wind. 100% is 1.0.
+	"""
+	windPct: Float
+}
+
+type ProjectLocalityExposureConnection {
+	"""
+	The total number of records in the connection.
+	"""
+	totalCount: Int64
+
+	"""
+	The edges of the connection.
+	"""
+	edges: [ProjectLocalityExposureEdge!]!
+
+	"""
+	The page info of the project jobs connection.
+	"""
+	pageInfo: PageInfo!
+}
+
+type ProjectLocalityExposureEdge {
+	"""
+	The cursor of the edge.
+	"""
+	cursor: String
+
+	"""
+	The node of the edge.
+	"""
+	node: ProjectLocalityExposure!
+}
+
+input ProjectLocalityExposureFilter {
+	"""
+	The parent locality id to filter the regional exposure by. Null is allowed only for top level (all countries). Non-null values for countries are ignored.
+	"""
+	parentLocalityId: Int64
+
+	"""
+	The locality type id to filter the regional exposure by. For "country" level (localityTypeId = 0) the `localityId` parameter is ignored.
+	"""
+	adminLevel: AdministrativeLevel!
+
+	"""
+	Socio-economic pathway of the prediction model. Defaults to SSP_2_45.
+	"""
+	ssp: SSP
+
+	"""
+	Relative year with current year being year 0. Defaults to 15.
+	"""
+	relativeYear: Int
+
+	"""
+	Get data for the locality ID at the adminLevel passed. Mutually exclusive with parentLocalityId.
+	"""
+	localityId: Int64
+}
+
+"""
+Sort order for the regional exposure connection.
+"""
+enum ProjectLocalityExposureSort {
+	DEFAULT
+	TOTAL_COUNT_ASC
+	TOTAL_COUNT_DESC
+	FLOOD_COUNT_ASC
+	FLOOD_COUNT_DESC
+	FLOOD_PCT_ASC
+	FLOOD_PCT_DESC
+	WILDFIRE_COUNT_ASC
+	WILDFIRE_COUNT_DESC
+	WILDFIRE_PCT_ASC
+	WILDFIRE_PCT_DESC
+	HEAT_COUNT_ASC
+	HEAT_COUNT_DESC
+	HEAT_PCT_ASC
+	HEAT_PCT_DESC
+	COLD_COUNT_ASC
+	COLD_COUNT_DESC
+	COLD_PCT_ASC
+	COLD_PCT_DESC
+	DROUGHT_COUNT_ASC
+	DROUGHT_COUNT_DESC
+	DROUGHT_PCT_ASC
+	DROUGHT_PCT_DESC
+	WIND_COUNT_ASC
+	WIND_COUNT_DESC
+	WIND_PCT_ASC
+	WIND_PCT_DESC
+}
+
+"""
+The default map for a project (individual asset).
+"""
+type ProjectMaps {
+	"""
+	The ID of the project.
+	"""
+	projectId: Int64!
+
+	"""
+	The default map for the project.
+	"""
+	default: Map
 }
 
 """
 Data to support module reports for a project.
 """
 type ProjectModuleData {
-    """
-    The ID of the project.
-    """
-    projectId: Int64!
+	"""
+	The ID of the project.
+	"""
+	projectId: Int64!
 
-    """
-    Project overview data.
-    """
-    overview: ModuleOverview
+	"""
+	Project overview data.
+	"""
+	overview: ModuleOverview
 
-    """
-    Data to support the Climate Exposure report.
-    """
-    climateExposure: ModuleClimateExposure
+	"""
+	Data to support the Climate Exposure report.
+	"""
+	climateExposure: ModuleClimateExposure
 
-    """
-    Data to support the Scenario Analysis report.
-    """
-    scenarioAnalysis: ModuleScenarioAnalysis
+	"""
+	Data to support the Scenario Analysis report.
+	"""
+	scenarioAnalysis: ModuleScenarioAnalysis
+
+	"""
+	Data to support the Company Overview report.
+	"""
+	companyOverview: ModuleCompanyOverview
+
+	"""
+	Data to support the Regional Exposure report.
+	"""
+	locality: ModuleLocality
+
+	"""
+	Data to support the Macroeconomic report.
+	"""
+	macroeconomic: ModuleMacroeconomic
+
+	"""
+	Data to support Linear Asset analysis.
+	"""
+	linearAssetAnalysis: ModuleLinearAssetAnalysis
+
+	"""
+	Data to support the Adaptation module.
+	"""
+	adaptation: ModuleAdaptation
+
+	"""
+	Data to support the Adaptation Summary module.
+	"""
+	adaptationSummary: ModuleAdaptationSummary
 }
 
 """
 Project Module Name.
 """
 enum ProjectModuleName {
-    CLIMATE_EXPOSURE
-    SCENARIO_ANALYSIS
+	CLIMATE_EXPOSURE
+	SCENARIO_ANALYSIS
+}
+
+enum ProjectSort {
+	CASH_GROSS_ASC
+	CASH_GROSS_DESC
+	ASSET_COUNT_ASC
+	ASSET_COUNT_DESC
+	REVENUE_ANNUAL_NET_ASC
+	REVENUE_ANNUAL_NET_DESC
+	CREATED_ON_ASC
+	CREATED_ON_DESC
+	INDUSTRY_RANK_ASC
+	INDUSTRY_RANK_DESC
+	SECTOR_RANK_ASC
+	SECTOR_RANK_DESC
+}
+
+input ProjectStagedAdaptationsInput {
+	"""
+	The project ID to get staged adaptations for.
+	"""
+	projectId: Int64!
+
+	"""
+	The place ID to get staged adaptations for.
+	"""
+	placeId: String!
+}
+
+"""
+The payload of getting an existing building customization.
+"""
+type ProjectStagedCustomBuildingValuesPayload {
+	"""
+	The building customization details.
+	"""
+	stagedBuilding: EnterpriseBuilding
 }
 
 """
 Status enum of a project.
 """
 enum ProjectStatus {
-    """
-    The project is active.
-    """
-    ACTIVE
+	"""
+	The project is active.
+	"""
+	ACTIVE
 
-    """
-    The project is archived.
-    """
-    ARCHIVED
+	"""
+	The project is archived.
+	"""
+	ARCHIVED
 
-    """
-    The project is locked. No changes can be made to the project.
-    """
-    LOCKED
+	"""
+	The project is locked. No changes can be made to the project.
+	"""
+	LOCKED
+
+	"""
+	The project is cloning.
+	"""
+	CLONING
+
+	"""
+	The project is deleting.
+	"""
+	DELETING
+
+	"""
+	The project is deleted.
+	"""
+	DELETED
 }
 
 """
@@ -2824,859 +7145,1666 @@ Project type indicates the type of project.
 CUSTOMER should be used for most use cases.
 """
 enum ProjectType {
-    CUSTOMER
-    EQUITY
+	CUSTOMER
+	EQUITY
 }
 
 """
 Project upload file format.
 """
 enum ProjectUploadFileFormat {
-    """
-    Upload the project in CSV format.
-    """
-    CSV
+	"""
+	Upload the project in CSV format.
+	"""
+	CSV
 
-    """
-    Upload the project in XLSX format.
-    """
-    XLSX
+	"""
+	Upload the project in XLSX format.
+	"""
+	XLSX
+
+	"""
+	Upload the project in GEOJSON format.
+	"""
+	GEOJSON
 }
 
 type ProjectUploadHeaders {
-    key: String!
-    value: String!
+	key: String!
+	value: String!
 }
 
 input ProjectUploadHeadersInput {
-    key: String!
-    value: String!
+	key: String!
+	value: String!
+}
+
+type ProjectsConnection {
+	"""
+	The total number of edges in the connection.
+	"""
+	totalCount: Int64
+
+	"""
+	The edges of the connection.
+	"""
+	edges: [ProjectEdge!]!
+
+	"""
+	The page info of the connection.
+	"""
+	pageInfo: PageInfo!
 }
 
 type Query {
-    """
-    Get project by id
-    """
-    project(projectId: Int64!): Project
+	"""
+	Get company projects with pagination.
+	"""
+	companiesConnection(
+		"""
+		Number of records(edges) to return. A number between 0 and 100.
+		"""
+		first: Int
 
-    """
-    Get all the projects.
-    """
-    projects: [Project!]!
+		"""
+		Cursor value of a record(edge) past which records should be returned. Cursor can be obtained from an earlier call. Cursor is a string between 10 and 32 characters long.
+		"""
+		after: String
 
-    """
-    Get project job by id
-    """
-    projectJob(projectJobId: Int64!): ProjectJob
+		"""
+		Sort the returned company projects
+		"""
+		sort: ProjectSort
 
-    """
-    Get all the project jobs the session user has access to.
-    """
-    projectJobs(filter: ProjectJobFilter): [ProjectJob!]!
+		"""
+		Filter the projects
+		"""
+		filter: CompanyFilter
+	): ProjectsConnection
 
-    """
-    Get all the project jobs the session user has access to, with pagination.
-    """
-    projectJobsConnection(
-        """
-        Number of records(edges) to return. A number between 0 and 100.
-        """
-        first: Int
+	"""
+	Get project by id
+	"""
+	project(projectId: Int64!): Project
 
-        """
-        Cursor value of a record(edge) past which records should be returned. Cursor can be obtained from an earlier call. Cursor is a string between 10 and 32 characters long.
-        """
-        after: String
+	"""
+	Get all the projects.
+	"""
+	projects: [Project!]!
+		@deprecated(
+			reason: "Use projectsConnection instead for pagination and sorting support"
+		)
 
-        """
-        Sort the project jobs
-        """
-        sort: ProjectJobsSort
+	"""
+	Get user group projects with pagination.
+	"""
+	projectsConnection(
+		"""
+		Number of records(edges) to return. A number between 0 and 100.
+		"""
+		first: Int
 
-        """
-        Filter the project jobs
-        """
-        filter: ProjectJobFilter
-    ): ProjectJobsConnection
+		"""
+		Cursor value of a record(edge) past which records should be returned. Cursor can be obtained from an earlier call. Cursor is a string between 10 and 32 characters long.
+		"""
+		after: String
 
-    """
-    Get user's groups custom building details for a specific place
-    """
-    userGroupCustomBuildingValues(placeId: String!): EnterpriseBuilding
+		"""
+		Sort the returned projects
+		"""
+		sort: ProjectSort
 
-    """
-    Get list of places viewed by the user
-    """
-    viewedPlacesConnection(
-        """
-        Number of records(edges) to return. A number between 0 and 100.
-        """
-        first: Int
+		"""
+		Filter the projects
+		"""
+		filter: ProjectFilter
+	): ProjectsConnection
 
-        """
-        Cursor value of a record(edge) past which records should be returned. Cursor can be obtained from an earlier call. Cursor is a string between 10 and 32 characters long.
-        """
-        after: String
+	"""
+	Get project job by id
+	"""
+	projectJob(projectJobId: Int64!): ProjectJob
 
-        """
-        Sort the viewed places
-        """
-        sort: ViewedPlacesSort
-    ): ViewedPlacesConnection
+	"""
+	Get all the project jobs the session user has access to.
+	"""
+	projectJobs(filter: ProjectJobFilter): [ProjectJob!]!
+		@deprecated(reason: "Redundant with ProjectJobsConnection")
+
+	"""
+	Get all the project jobs the session user has access to, with pagination.
+	"""
+	projectJobsConnection(
+		"""
+		Number of records(edges) to return. A number between 0 and 100.
+		"""
+		first: Int
+
+		"""
+		Cursor value of a record(edge) past which records should be returned. Cursor can be obtained from an earlier call. Cursor is a string between 10 and 32 characters long.
+		"""
+		after: String
+
+		"""
+		Sort the project jobs
+		"""
+		sort: ProjectJobsSort
+
+		"""
+		Filter the project jobs
+		"""
+		filter: ProjectJobFilter
+	): ProjectJobsConnection
+
+	"""
+	Get portfolio-level custom building details for a specific place
+	"""
+	projectCustomBuildingValues(
+		input: ProjectCustomBuildingValuesInput!
+	): ProjectCustomBuildingValuesPayload!
+
+	"""
+	Get portfolio-level staged custom building details for a specific place
+	"""
+	projectStagedCustomBuildingValues(
+		input: ProjectCustomBuildingValuesInput!
+	): ProjectStagedCustomBuildingValuesPayload!
+
+	"""
+	Get user's groups custom building details for a specific place
+	"""
+	userGroupCustomBuildingValues(placeId: String!): EnterpriseBuilding
+
+	"""
+	Get user's groups staged adaptations for a specific place
+	"""
+	userGroupStagedAdaptations(placeId: String!): [StagedAdaptation]!
+
+	"""
+	Get project-level staged adaptations for a specific place
+	"""
+	projectStagedAdaptations(
+		input: ProjectStagedAdaptationsInput!
+	): [StagedAdaptation]!
+
+	"""
+	Get list of places viewed by the user
+	"""
+	viewedPlacesConnection(
+		"""
+		Number of records(edges) to return. A number between 0 and 100.
+		"""
+		first: Int
+
+		"""
+		Cursor value of a record(edge) past which records should be returned. Cursor can be obtained from an earlier call. Cursor is a string between 10 and 32 characters long.
+		"""
+		after: String
+
+		"""
+		Sort the viewed places
+		"""
+		sort: ViewedPlacesSort
+	): ViewedPlacesConnection
+
+	"""
+	Get a list of the user's most recently viewed places and portfolios
+	"""
+	viewedHistoryList(sort: ViewedItemsSort): ViewedHistoryList
+
+	"""
+	Get project localities. Returns localities present across all project assets.
+	"""
+	projectLocalities(input: ProjectLocalitiesInput!): ProjectLocalitiesPayload!
+
+	"""
+	Autocomplete projects
+	"""
+	projectAutocomplete(
+		input: ProjectAutocompleteInput!
+	): ProjectAutocompletePayload @deprecated(reason: "WIP")
+
+	"""
+	Get a single project asset info
+	"""
+	projectAsset(projectId: Int64!, placeId: String!): ProjectAsset
+
+	"""
+	Get link share details by link ID.
+	"""
+	linkShare(input: LinkShareInput!): LinkSharePayload!
+
+	"""
+	Get paginated list of link shares created by the current user.
+	"""
+	linkSharesConnection(
+		"""
+		Number of records(edges) to return. A number between 0 and 100.
+		"""
+		first: Int
+
+		"""
+		Cursor value of a record(edge) past which records should be returned.
+		"""
+		after: String
+
+		"""
+		Sort order for the link shares.
+		"""
+		sort: LinkSharesSort
+	): LinkSharesConnection
+
+	"""
+	Get the full ancestor path from root to the given project, ordered root-to-leaf.
+	"""
+	portfolioPath(projectId: Int64!): [PortfolioPathNode!]!
+
+	"""
+	Get the current user's group and subgroups.
+	"""
+	userGroup: UserGroup
+
+	"""
+	Get a portfolio with its own info and paginated descendants in a single call.
+	"""
+	portfolio(input: PortfolioInput): Portfolio!
+}
+
+input RefreshPortfolioInput {
+	portfolioId: Int64!
 }
 
 input RefreshProjectModuleInput {
-    """
-    The ID of the project to update.
-    """
-    projectId: Int64!
+	"""
+	The ID of the project to update.
+	"""
+	projectId: Int64!
 
-    """
-    The name of the project job.
-    """
-    projectJobName: String!
+	"""
+	The name of the project job.
+	"""
+	projectJobName: String!
+
+	"""
+	The vintage version to use for the project refresh. Vintage uniquely identifies the place and peril data version. Leave empty to use the latest vintage.
+	"""
+	vintageId: Int64
 }
 
 """
 The payload of refreshing a module.
 """
 type RefreshProjectModulePayload {
-    """
-    The created project job.
-    """
-    projectJob: ProjectJob
+	"""
+	The created project job.
+	"""
+	projectJob: ProjectJob
+}
+
+type RegionalExposure {
+	"""
+	The region affected by the hazard.
+	"""
+	region: String!
+
+	"""
+	The number of assets in the region.
+	"""
+	totalCount: Int64!
+
+	"""
+	The number of assets in the region exposed to the flood hazard.
+	"""
+	floodExposedCount: Int64!
+
+	"""
+	The percentage of assets in the region exposed to the flood hazard.
+	"""
+	floodExposedPercent: Float!
+
+	"""
+	The number of assets in the region exposed to the wind hazard.
+	"""
+	windExposedCount: Int64!
+
+	"""
+	The percentage of assets in the region exposed to the wind hazard.
+	"""
+	windExposedPercent: Float!
+
+	"""
+	The number of assets in the region exposed to the wildfire hazard.
+	"""
+	wildfireExposedCount: Int64!
+
+	"""
+	The percentage of assets in the region exposed to the wildfire hazard.
+	"""
+	wildfireExposedPercent: Float!
+
+	"""
+	The number of assets in the region exposed to the heat hazard.
+	"""
+	heatExposedCount: Int64!
+
+	"""
+	The percentage of assets in the region exposed to the heat hazard.
+	"""
+	heatExposedPercent: Float!
+
+	"""
+	The number of assets in the region exposed to the cold hazard.
+	"""
+	coldExposedCount: Int64!
+
+	"""
+	The percentage of assets in the region exposed to the cold hazard.
+	"""
+	coldExposedPercent: Float!
+
+	"""
+	The number of assets in the region exposed to drought hazard.
+	"""
+	droughtExposedCount: Int64!
+
+	"""
+	The percentage of assets in the region exposed to drought hazard.
+	"""
+	droughtExposedPercent: Float!
+}
+
+"""
+The input to set for the regional exposure.
+"""
+input RegionalExposureInput {
+	"""
+	The country of the regions to analyze. Leave empty for all countries.
+	"""
+	countryRegion: String
+
+	"""
+	The administrative level one of the regions to analyze. Leave empty for all administrative level ones.
+	"""
+	administrativeLevelOne: String
 }
 
 """
 Generic request status object
 """
 type RequestStatus {
-    """
-    Indicates if the request was successful.
-    """
-    success: Boolean!
+	"""
+	Indicates if the request was successful.
+	"""
+	success: Boolean!
 }
 
 enum ReturnPeriod {
-    """
-    2-year return period (50% chance)
-    """
-    RP2
+	"""
+	2-year return period (50% chance)
+	"""
+	RP2
 
-    """
-    5-year return period (20% chance)
-    """
-    RP5
+	"""
+	5-year return period (20% chance)
+	"""
+	RP5
 
-    """
-    20-year return period (5% chance)
-    """
-    RP20
+	"""
+	20-year return period (5% chance)
+	"""
+	RP20
 
-    """
-    100-year return period (1% chance)
-    """
-    RP100
+	"""
+	100-year return period (1% chance)
+	"""
+	RP100
 
-    """
-    200-year return period (0.5% chance)
-    """
-    RP200
+	"""
+	200-year return period (0.5% chance)
+	"""
+	RP200
 
-    """
-    300-year return period (0.33% chance)
-    """
-    RP300
+	"""
+	300-year return period (0.33% chance)
+	"""
+	RP300
 
-    """
-    500-year return period (0.2% chance)
-    """
-    RP500
+	"""
+	500-year return period (0.2% chance)
+	"""
+	RP500
+}
+
+type RisksByValueChainData {
+	"""
+	Name of the value chain position.
+	"""
+	valueChain: String!
+
+	"""
+	The relative year with current year being year 0.
+	"""
+	relativeYear: Int64!
+
+	"""
+	Socio-economic pathway of the prediction model.
+	"""
+	ssp: SSP!
+
+	"""
+	Number of assets in this value chain that are exposed to flood damage risk.
+	"""
+	floodDamageCount: Int64!
+
+	"""
+	Percentage of assets in this value chain that are exposed to flood damage risk.
+	"""
+	floodDamagePercent: Float
+
+	"""
+	Number of assets in this value chain that are exposed to wind damage risk.
+	"""
+	windDamageCount: Int64!
+
+	"""
+	Percentage of assets in this value chain that are exposed to wind damage risk.
+	"""
+	windDamagePercent: Float
+
+	"""
+	Number of assets in this value chain that are exposed to fire damage risk.
+	"""
+	fireDamageCount: Int64!
+
+	"""
+	Percentage of assets in this value chain that are exposed to fire damage risk.
+	"""
+	fireDamagePercent: Float
 }
 
 enum RoofCombustibilityLevel {
-    LOW
-    MEDIUM
-    HIGH
+	LOW
+	MEDIUM
+	HIGH
 }
 
 enum RoofType {
-    ASBESTOS
-    BUILT_UP
-    COMPOSITION_SHINGLE
-    CONCRETE
-    METAL
-    SLATE
-    GRAVEL_OR_ROCK
-    TAR_AND_GRAVEL
-    BERMUDA
-    MASONITE_OR_CEMENT_SHAKE
-    FIBERGLASS
-    ALUMINUM
-    WOOD_SHAKE_OR_SHINGLES
-    OTHER
-    ASPHALT
-    ROLL_COMPOSITION
-    STEEL
-    TILE
-    URETHANE
-    NON_WOODEN_SHINGLES
-    WOOD
-    GYPSUM
-    SOLAR
-    CERAMIC_TILE
-    CLAY_TILE
-    CONCRETE_TILE
-    COPPER
-    TIN
+	ASBESTOS
+	BUILT_UP
+	COMPOSITION_SHINGLE
+	CONCRETE
+	METAL
+	SLATE
+	GRAVEL_OR_ROCK
+	TAR_AND_GRAVEL
+	BERMUDA
+	MASONITE_OR_CEMENT_SHAKE
+	FIBERGLASS
+	ALUMINUM
+	WOOD_SHAKE_OR_SHINGLES
+	OTHER
+	ASPHALT
+	ROLL_COMPOSITION
+	STEEL
+	TILE
+	URETHANE
+	NON_WOODEN_SHINGLES
+	WOOD
+	GYPSUM
+	SOLAR
+	CERAMIC_TILE
+	CLAY_TILE
+	CONCRETE_TILE
+	COPPER
+	TIN
 }
 
 """
 Supported Shared Socio-economic Pathways.
 """
 enum SSP {
-    """
-    The most optimistic climate scenario, projecting the lowest temperature increase.
-    Assumes strong climate action leading to warming limited to about 2°C by 2100.
-    """
-    SSP_1_26
+	"""
+	The most optimistic climate scenario, projecting the lowest temperature increase.
+	Assumes strong climate action leading to warming limited to about 2°C by 2100.
+	"""
+	SSP_1_26
 
-    """
-    A middle-ground climate scenario with moderate emissions reductions.
-    Projects medium levels of climate change and warming by 2100.
-    """
-    SSP_2_45
+	"""
+	A middle-ground climate scenario with moderate emissions reductions.
+	Projects medium levels of climate change and warming by 2100.
+	"""
+	SSP_2_45
 
-    """
-    The most pessimistic climate scenario with highest emissions.
-    Projects the most severe climate impacts and warming by 2100.
-    """
-    SSP_5_85
+	"""
+	The most pessimistic climate scenario with highest emissions.
+	Projects the most severe climate impacts and warming by 2100.
+	"""
+	SSP_5_85
+}
+
+input SaveViewHistoryInput {
+	"""
+	placeId of the viewed history item.
+	"""
+	placeId: String
+
+	"""
+	projectId of the viewed history item.
+	"""
+	projectId: ID
+}
+
+type SaveViewHistoryPayload {
+	viewedHistoryItem: ViewedHistoryItem
 }
 
 type ScenarioAnalysisAAL {
-    """
-    Peril the data appies to. 2 = inland flood, 3 = hurricane, 4 = wildfire, 5 = overall.
-    """
-    perilId: Int!
+	"""
+	Peril the data applies to. 2 = inland flood, 3 = hurricane, 4 = wildfire, 5 = overall.
+	"""
+	perilId: Int!
 
-    """
-    Socio-economic pathway of the prediction model.
-    """
-    ssp: SSP!
+	"""
+	Socio-economic pathway of the prediction model.
+	"""
+	ssp: SSP!
 
-    """
-    The relative year with current year being year 0.
-    """
-    relativeYear: Int64!
+	"""
+	The relative year with current year being year 0.
+	"""
+	relativeYear: Int64!
 
-    """
-    Percentile value for estimates, one of: 10, 50, 90. 10th percentile estimate is low value, 90th percentile is high value, and 50th is mean. At this moment, only 50th percentile is available for this node.
-    """
-    percentile: Int64!
+	"""
+	Percentile value for estimates, one of: 10, 50, 90. 10th percentile estimate is low value, 90th percentile is high value, and 50th is mean. At this moment, only 50th percentile is available for this node.
+	"""
+	percentile: Int64!
 
-    """
-    Total project level direct gross Average Annual Loss from cat events
-    """
-    directGrossAAL: Int64!
+	"""
+	Total project level direct gross Average Annual Loss from cat events
+	"""
+	directGrossAAL: Int64!
 
-    """
-    Total project direct gross Average Annual Loss as a % of Total asset value
-    """
-    directGrossAALPercent: Float!
+	"""
+	Total project direct gross Average Annual Loss as a % of Total asset value
+	"""
+	directGrossAALPercent: Float!
 
-    """
-    Total project level direct net Average Annual Loss from cat events
-    """
-    directNetAAL: Int64!
+	"""
+	Total project level direct net Average Annual Loss from cat events
+	"""
+	directNetAAL: Int64!
 
-    """
-    Total project direct net Average Annual Loss as a % of Total asset value
-    """
-    directNetAALPercent: Float!
+	"""
+	Total project direct net Average Annual Loss as a % of Total asset value
+	"""
+	directNetAALPercent: Float!
 
-    """
-    Total project level BI gross Average Annual Loss from cat events
-    """
-    businessInterruptionGrossAAL: Int64!
+	"""
+	Total project level BI gross Average Annual Loss from cat events
+	"""
+	businessInterruptionGrossAAL: Int64!
 
-    """
-    Total project BI gross Average Annual Loss as a % of Total asset value
-    """
-    businessInterruptionGrossAALPercent: Float!
+	"""
+	Total project BI gross Average Annual Loss as a % of Total asset value
+	"""
+	businessInterruptionGrossAALPercent: Float!
 
-    """
-    Total project level BI net Average Annual Loss from cat events
-    """
-    businessInterruptionNetAAL: Int64!
+	"""
+	Total project level BI net Average Annual Loss from cat events
+	"""
+	businessInterruptionNetAAL: Int64!
 
-    """
-    Total project BI net Average Annual Loss as a % of Total asset value
-    """
-    businessInterruptionNetAALPercent: Float!
+	"""
+	Total project BI net Average Annual Loss as a % of Total asset value
+	"""
+	businessInterruptionNetAALPercent: Float!
 
-    """
-    Total portfolio level cash gross Average Annual Loss from cat events
-    """
-    cashGrossAAL: Int64!
+	"""
+	Total portfolio level cash gross Average Annual Loss from cat events
+	"""
+	cashGrossAAL: Int64!
 
-    """
-    Total portfolio cash gross Average Annual Loss as a % of Total Property Value
-    """
-    cashGrossAALPercent: Float!
+	"""
+	Total portfolio cash gross Average Annual Loss as a % of Total Property Value
+	"""
+	cashGrossAALPercent: Float!
 
-    """
-    Total portfolio level cash net Average Annual Loss from cat events
-    """
-    cashNetAAL: Int64!
+	"""
+	Total portfolio level cash net Average Annual Loss from cat events
+	"""
+	cashNetAAL: Int64!
 
-    """
-    Total portfolio cash net Average Annual Loss as a % of Total asset value
-    """
-    cashNetAALPercent: Float!
+	"""
+	Total portfolio cash net Average Annual Loss as a % of Total asset value
+	"""
+	cashNetAALPercent: Float!
 }
 
 type ScenarioAnalysisData {
-    projectEffects: [ProjectEffects]
-    aal: [ScenarioAnalysisAAL]
+	projectEffects: [ProjectEffects]
+	aal: [ScenarioAnalysisAAL]
+}
+
+type Sector {
+	"""
+	The ID of the sector.
+	"""
+	id: Int64!
+
+	"""
+	The name of the sector.
+	"""
+	name: String!
 }
 
 """
 Severity
 """
 enum Severity {
-    ERROR
-    WARNING
+	ERROR
+	WARNING
+}
+
+type StagedAdaptation {
+	"""
+	The staged adaptation.
+	"""
+	adaptation: AdaptationType!
+
+	"""
+	Custom annual cost of the adaptation.
+	"""
+	annualCost: Int64
+
+	"""
+	Custom setup cost of the adaptation.
+	"""
+	setupCost: Int64
+}
+
+input StagedAdaptationInput {
+	"""
+	The staged adaptation.
+	"""
+	adaptation: AdaptationType!
+
+	"""
+	Custom annual cost of the adaptation.
+	"""
+	annualCost: Int64
+
+	"""
+	Custom setup cost of the adaptation.
+	"""
+	setupCost: Int64
 }
 
 """
 A staged asset is an initial asset imported from a project job. It is meant to be reviewed and committed to a project.
 """
 type StagedAsset {
-    """
-    The ID of the staged asset.
-    """
-    stagedAssetId: String!
+	"""
+	The ID of the staged asset.
+	"""
+	stagedAssetId: String!
 
-    """
-    The project job that created this staged asset.
-    """
-    projectJob: ProjectJob
+	"""
+	The project job that created this staged asset.
+	"""
+	projectJob: ProjectJob
 
-    """
-    The place ID of the asset.
-    """
-    placeID: String
+	"""
+	The place ID of the asset.
+	"""
+	placeID: String
 
-    """
-    The original CSV input of the asset. For informational purposes only. Will be discarded when the staged asset is imported into a project.
-    """
-    rawInputs: String
+	"""
+	The original CSV input of the asset. For informational purposes only. Will be discarded when the staged asset is imported into a project.
+	"""
+	rawInputs: String
 
-    """
-    The customer source ID of the asset.
-    """
-    customId: String
+	"""
+	The customer source ID of the asset.
+	"""
+	customId: String
 
-    """
-    The alias of the asset.
-    """
-    alias: String
+	"""
+	The alias of the asset.
+	"""
+	alias: String
 
-    """
-    The corresponding asset type ID for the asset.
-    """
-    assetTypeId: AssetTypeId
+	"""
+	The corresponding asset type ID for the asset.
+	"""
+	assetTypeId: AssetTypeId
 
-    """
-    The latitude of the asset.
-    """
-    lat: Float
+	"""
+	The latitude of the asset.
+	"""
+	lat: Float
 
-    """
-    The longitude of the asset.
-    """
-    lng: Float
+	"""
+	The longitude of the asset.
+	"""
+	lng: Float
 
-    """
-    The address of the asset.
-    """
-    address: String
+	"""
+	The geometry of the asset. This is used to support map display for sub-assets which are part of complex features, such as linear and area assets.
+	"""
+	geometry: String
 
-    """
-    The country of the asset, Iso-3166-a3 country code.
-    """
-    country: String
+	"""
+	The address of the asset.
+	"""
+	address: String
 
-    """
-    Most recent valuation in US dollars. Required for some financial impact metrics.
-    """
-    placeValuation: Int64
+	"""
+	The country of the asset, Iso-3166-a3 country code.
+	"""
+	country: String
 
-    """
-    Date of most recent valuation assessment. YYYY-MM-DD format.
-    """
-    placeValueDate: Date
+	"""
+	Most recent valuation in US dollars. Required for some financial impact metrics.
+	"""
+	placeValuation: Int64
 
-    """
-    Outstanding balance in US dollars.
-    """
-    placeOutstandingBalance: Int64
+	"""
+	Date of most recent valuation assessment. YYYY-MM-DD format.
+	"""
+	placeValueDate: Date
 
-    """
-    Annual Net Operating Income. Required for some financial impact metrics.
-    """
-    placeNOI: Int
+	"""
+	Outstanding balance in US dollars.
+	"""
+	placeOutstandingBalance: Int64
 
-    """
-    Land use type. See documentation for accepted values.
-    """
-    placeType: LandUseType
+	"""
+	Annual Net Operating Income. Required for some financial impact metrics.
+	"""
+	placeNOI: Int
 
-    """
-    The rebuild price per square foot for a structure (if it exists). Used to compute building damages.
-    """
-    rebuildCostPerSf: Int64
+	"""
+	Land use type. See documentation for accepted values.
+	"""
+	placeType: LandUseType
 
-    """
-    Total square footage for the structure.
-    """
-    buildingSf: Int
+	"""
+	The rebuild price per square foot for a structure (if it exists). Used to compute building damages.
+	"""
+	rebuildCostPerSf: Int64
 
-    """
-    Orientation of building. Options are N (default), NE, E, SE, S, SW, W, NW.
-    """
-    buildingDirection: CompassDirection
+	"""
+	Total square footage for the structure.
+	"""
+	buildingSf: Int
 
-    """
-    The presence of defensible space around this property.
-    true = adequate defensible space exists, defined as a five foot buffer zone of cleared space around house AND <15% tree canopy within 50 ft. false (default) = defensible space does not exist.
-    """
-    defensibleSpace: Boolean
+	"""
+	Orientation of building. Options are N (default), NE, E, SE, S, SW, W, NW.
+	"""
+	buildingDirection: CompassDirection
 
-    """
-    Number of units in structure. Default = 1.
-    """
-    units: Int
+	"""
+	The presence of defensible space around this property.
+	true = adequate defensible space exists, defined as a five foot buffer zone of cleared space around house AND <15% tree canopy within 50 ft. false (default) = defensible space does not exist.
+	"""
+	defensibleSpace: Boolean
 
-    """
-    Number of stories. Default = 1.
-    """
-    stories: Int
+	"""
+	Number of units in structure. Default = 1.
+	"""
+	units: Int
 
-    """
-    Foundation height (or first floor elevation) in feet.
-    """
-    foundationHeightFt: Float
+	"""
+	Number of stories. Default = 1.
+	"""
+	stories: Int
 
-    """
-    The type of foundation. Used when exact foundation height isn't available.
-    """
-    foundationType: FoundationType
+	"""
+	Foundation height (or first floor elevation) in feet.
+	"""
+	foundationHeightFt: Float
 
-    """
-    Whether or not the property has a basement.
-    """
-    basement: Basement
+	"""
+	The type of foundation. Used when exact foundation height isn't available.
+	"""
+	foundationType: FoundationType
 
-    """
-    The predominant construction material of the building.
-    """
-    constructionType: ConstructionType
+	"""
+	Whether or not the property has a basement.
+	"""
+	basement: Basement
 
-    """
-    The type of roofing material.
-    """
-    roofType: RoofType
+	"""
+	The predominant construction material of the building.
+	"""
+	constructionType: ConstructionType
 
-    """
-    Year of construction.
-    """
-    yearBuilt: Int
+	"""
+	The type of roofing material.
+	"""
+	roofType: RoofType
 
-    """
-    Whether or not the property abides by the Fireproofing building code.
-    true = fire proofing measures exist for the home (such as fire-proofed windows, flame resistant exterior walls and ignition-resistant exterior doors). false (default) = does not exist.
-    """
-    fireProofing: Boolean
+	"""
+	Year of construction.
+	"""
+	yearBuilt: Int
 
-    """
-    Likelihood of damaging airborne missile in this vicinity. Based on built-up density at the Census tract level.
-    """
-    denseUrbanEnvironment: MissileEnvironment
+	"""
+	Whether or not the property abides by the Fireproofing building code.
+	true = fire proofing measures exist for the home (such as fire-proofed windows, flame resistant exterior walls and ignition-resistant exterior doors). false (default) = does not exist.
+	"""
+	fireProofing: Boolean
 
-    """
-    The expected design standard of structures, based on ASCE 7-22 wind risk zones
-    """
-    windDesignStandard: WindDesignStandard
+	"""
+	Likelihood of damaging airborne missile in this vicinity. Based on built-up density at the Census tract level.
+	"""
+	denseUrbanEnvironment: MissileEnvironment
 
-    """
-    Dollar value of wildfire insurance coverage sublimit (default: place valuation)
-    """
-    wildfireInsuredValue: Int64
+	"""
+	The expected design standard of structures, based on ASCE 7-22 wind risk zones
+	"""
+	windDesignStandard: WindDesignStandard
 
-    """
-    Wildfire insurance deductible amount in dollars (default: $100,000)
-    """
-    wildfireDeductible: Int64
+	"""
+	Dollar value of wildfire insurance coverage sublimit (default: place valuation)
+	"""
+	wildfireInsuredValue: Int64
 
-    """
-    Wildfire insurance deductible as percentage of insured value (if dollar value unavailable). 1.0 = 100%
-    """
-    wildfireDeductiblePerc: Float
+	"""
+	Wildfire insurance deductible amount in dollars (default: $100,000)
+	"""
+	wildfireDeductible: Int64
 
-    """
-    true (default) = business interruption losses are covered under total wildfire insurance sublimit. false = business interruption losses are not covered
-    """
-    wildfireBICoverageIncluded: Boolean
+	"""
+	Wildfire insurance deductible as percentage of insured value (if dollar value unavailable). 1.0 = 100%
+	"""
+	wildfireDeductiblePerc: Float
 
-    """
-    Dollar value of wind insurance coverage sublimit (default: place valuation)
-    """
-    windInsuredValue: Int64
+	"""
+	true (default) = business interruption losses are covered under total wildfire insurance sublimit. false = business interruption losses are not covered
+	"""
+	wildfireBICoverageIncluded: Boolean
 
-    """
-    Wind insurance deductible amount in dollars (default: $100,000)
-    """
-    windDeductible: Int64
+	"""
+	Dollar value of wind insurance coverage sublimit (default: place valuation)
+	"""
+	windInsuredValue: Int64
 
-    """
-    Wind insurance deductible as percentage of insured value (if dollar value unavailable). 1.0 = 100%
-    """
-    windDeductiblePerc: Float
+	"""
+	Wind insurance deductible amount in dollars (default: $100,000)
+	"""
+	windDeductible: Int64
 
-    """
-    true (default) = business interruption losses are covered under total wind insurance sublimit. false = business interruption losses are not covered
-    """
-    windBICoverageIncluded: Boolean
+	"""
+	Wind insurance deductible as percentage of insured value (if dollar value unavailable). 1.0 = 100%
+	"""
+	windDeductiblePerc: Float
 
-    """
-    Dollar value of flood insurance coverage sublimit (default: $0)
-    """
-    floodInsuredValue: Int64
+	"""
+	true (default) = business interruption losses are covered under total wind insurance sublimit. false = business interruption losses are not covered
+	"""
+	windBICoverageIncluded: Boolean
 
-    """
-    Flood insurance deductible amount in dollars (default: $0)
-    """
-    floodDeductible: Int64
+	"""
+	Dollar value of flood insurance coverage sublimit (default: $0)
+	"""
+	floodInsuredValue: Int64
 
-    """
-    Flood insurance deductible as percentage of insured value (if dollar value unavailable). 1.0 = 100%
-    """
-    floodDeductiblePerc: Float
+	"""
+	Flood insurance deductible amount in dollars (default: $100,000)
+	"""
+	floodDeductible: Int64
 
-    """
-    true (default) = business interruption losses are covered under total flood insurance sublimit. false = business interruption losses are not covered
-    """
-    floodBICoverageIncluded: Boolean
+	"""
+	Flood insurance deductible as percentage of insured value (if dollar value unavailable). 1.0 = 100%
+	"""
+	floodDeductiblePerc: Float
 
-    """
-    Validation information about the staged asset.
-    """
-    issues: [Issue!]!
+	"""
+	true (default) = business interruption losses are covered under total flood insurance sublimit. false = business interruption losses are not covered
+	"""
+	floodBICoverageIncluded: Boolean
+
+	"""
+	Occupancy type of the building.
+	"""
+	occupancyType: OccupancyType
+
+	"""
+	The replacement costs of the contents within the building.
+	"""
+	contentsCost: Int64
+
+	"""
+	The replacement costs of the inventory within the building.
+	"""
+	inventoryCost: Int64
+
+	"""
+	Validation information about the staged asset.
+	"""
+	issues: [Issue!]!
+
+	"""
+	The geocode quality score of the asset from company data or geocoder
+	"""
+	geocodeQualityScore: Int
 }
 
 """
 A list of staged assets.
 """
 type StagedAssetConnection {
-    """
-    Return a list of type that wraps edge type.
-    """
-    edges: [StagedAssetEdge!]!
+	"""
+	Return a list of type that wraps edge type.
+	"""
+	edges: [StagedAssetEdge!]!
 
-    """
-    Pagination information in relation to current page.
-    """
-    pageInfo: PageInfo!
+	"""
+	Pagination information in relation to current page.
+	"""
+	pageInfo: PageInfo!
 
-    """
-    Total number of records for the connection.
-    """
-    totalCount: Int64
+	"""
+	Total number of records for the connection.
+	"""
+	totalCount: Int64
 }
 
 """
 Represents a staged asset edge of the current project job.
 """
 type StagedAssetEdge {
-    """
-    Cursor is a string that can be used in subsequent request as value of a connection "after" argument, to request page starting after this item.
-    Example: *Y3Vyc29yOjEyNTI0MA==*
-    """
-    cursor: String
+	"""
+	Cursor is a string that can be used in subsequent request as value of a connection "after" argument, to request page starting after this item.
+	Example: *Y3Vyc29yOjEyNTI0MA==*
+	"""
+	cursor: String
 
-    """
-    Contains one page record data.
-    """
-    node: StagedAsset!
+	"""
+	Contains one page record data.
+	"""
+	node: StagedAsset!
 }
 
 """
 The input to filter staged assets.
 """
 input StagedAssetFilter {
-    """
-    Return staged assets that have errors.
-    """
-    hasErrors: Boolean
+	"""
+	Return staged assets that have errors.
+	"""
+	hasErrors: Boolean
 
-    """
-    Return staged assets that have warnings.
-    """
-    hasWarnings: Boolean
+	"""
+	Return staged assets that have warnings.
+	"""
+	hasWarnings: Boolean
 
-    """
-    Return the staged asset that contains the given value in the address, alias or customer ID.
-    """
-    searchValue: String
+	"""
+	Return the staged asset that contains the given value in the address, alias or customer ID.
+	"""
+	searchValue: String
 
-    """
-    Return staged assets that are duplicates.
-    """
-    isDuplicate: Boolean
+	"""
+	Return staged assets that are duplicates.
+	"""
+	isDuplicate: Boolean
 }
 
 """
 Sort order for the staged asset connection.
 """
 enum StagedAssetSort {
-    DEFAULT
-    CUSTOM_ID_ASC
-    CUSTOM_ID_DESC
-    PLACE_ID_ASC
-    PLACE_ID_DESC
-    ERROR_ASC
-    ERROR_DESC
+	DEFAULT
+	CUSTOM_ID_ASC
+	CUSTOM_ID_DESC
+	PLACE_ID_ASC
+	PLACE_ID_DESC
+	ERROR_ASC
+	ERROR_DESC
 }
+
+scalar Time
 
 """
 The payload of updating an existing building customization.
 """
 type UpdateCustomBuildingValuesPayload {
-    """
-    Indicates if the building customization was updated successfully.
-    """
-    success: Boolean!
+	"""
+	Indicates if the building customization was updated successfully.
+	"""
+	success: Boolean!
 
-    """
-    The updated building customization.
-    """
-    building: EnterpriseBuilding
+	"""
+	The updated building customization.
+	"""
+	building: EnterpriseBuilding
 }
 
 """
 The input to update an existing building customization.
 """
 input UpdateCustomEnterpriseBuildingValuesInput {
-    """
-    The new building customization details.
-    """
-    building: EnterpriseBuildingInput!
+	"""
+	The new building customization details.
+	"""
+	building: EnterpriseBuildingInput!
+}
+
+"""
+Input for updating link share.
+"""
+input UpdateLinkShareInput {
+	"""
+	ID of the link share to update.
+	"""
+	linkId: String!
+
+	"""
+	Number of hours until the link expires. When 0 is provided the link will never expire.
+	"""
+	expirationInHours: Int!
+
+	"""
+	If true, expires the link share immediately. Takes precedence over `expirationInHours` parameter.
+	"""
+	expireImmediately: Boolean
+}
+
+"""
+Payload for the updating link share.
+"""
+type UpdateLinkSharePayload {
+	link: LinkShare!
+}
+
+"""
+Input for updating portfolio asset details.
+"""
+input UpdatePortfolioAssetDetailsInput {
+	projectId: Int64!
+	typeId: AssetTypeId
+	operatingIncome: Int64
+	bookValue: Int64
+}
+
+input UpdatePortfolioParentInput {
+	"""
+	New parent portfolio ID of the portfolio to be moved.
+	"""
+	targetParentPortfolioId: Int64!
+
+	"""
+	ID of the portfolio to be moved
+	"""
+	portfolioId: Int64!
+
+	"""
+	Optional new project name to use when this input is used for copy/clone operations.
+	"""
+	projectName: String
+}
+
+input UpdateProjectCustomBuildingValuesInput {
+	"""
+	Project ID the building belongs to.
+	"""
+	projectId: Int64!
+
+	"""
+	The new building customization details.
+	"""
+	building: EnterpriseBuildingInput!
+}
+
+"""
+The payload of updating an existing building customization.
+"""
+type UpdateProjectCustomBuildingValuesPayload {
+	"""
+	Indicates if the building customization was updated successfully.
+	"""
+	success: Boolean!
+
+	"""
+	The updated building customization.
+	"""
+	building: EnterpriseBuilding
 }
 
 """
 The input to update a project.
 """
 input UpdateProjectInput {
-    """
-    The ID of the project to update.
-    """
-    projectId: Int64!
+	"""
+	The ID of the project to update.
+	"""
+	projectId: Int64!
 
-    """
-    The new name of the project.
-    """
-    name: String!
+	"""
+	The new name of the project.
+	"""
+	name: String!
 
-    """
-    The new description of the project.
-    """
-    description: String
+	"""
+	The new description of the project.
+	"""
+	description: String
+}
+
+input UpdateProjectStagedAdaptationsInput {
+	"""
+	The project ID to update staged adaptations for.
+	"""
+	projectId: Int64!
+
+	"""
+	The place ID to update staged adaptations for.
+	"""
+	placeId: String!
+
+	"""
+	The new staged adaptations.
+	"""
+	adaptations: [StagedAdaptationInput!]!
+}
+
+input UpdateProjectStagedAdaptationsPlanInput {
+	"""
+	The project ID to update staged adaptations for.
+	"""
+	projectId: Int64!
+
+	"""
+	The adaptations plan to update the Project with.
+	"""
+	adaptations: [ProjectAdaptationPlanItem!]!
+}
+
+"""
+The input to update an existing building customization.
+"""
+input UpdateProjectStagedCustomBuildingValuesInput {
+	"""
+	The ID of the project to export.
+	"""
+	projectId: Int64!
+
+	"""
+	The new staged building customization details.
+	"""
+	stagedBuilding: EnterpriseBuildingInput!
+}
+
+"""
+The payload of updating an existing building customization.
+"""
+type UpdateProjectStagedCustomBuildingValuesPayload {
+	"""
+	Indicates if the building customization was updated successfully.
+	"""
+	success: Boolean!
+
+	"""
+	The updated staged building customization.
+	"""
+	stagedBuilding: EnterpriseBuilding
+}
+
+input UpdateREAParentInput {
+	"""
+	Target parent portfolio ID of the portfolio to be moved.
+	"""
+	targetParentPortfolioId: Int64!
+
+	"""
+	Current portfolio ID of the asset
+	"""
+	currentParentPortfolioId: Int64!
+
+	"""
+	Place ID of the projectAsset to be moved
+	"""
+	placeId: String!
+}
+
+input UpdateUserGroupStagedAdaptationsInput {
+	"""
+	The ID of the place to update staged adaptations for.
+	"""
+	placeId: String!
+
+	"""
+	The new staged adaptations.
+	"""
+	adaptations: [StagedAdaptationInput!]!
 }
 
 """
 An upload job is a project job that creates staged assets from an uploaded file.
 """
 type UploadJob implements ProjectJob {
-    """
-    The ID of the project job. Note this ID as you'll need it when importing assets from project job to project.
-    """
-    projectJobId: Int64!
+	"""
+	The ID of the project job. Note this ID as you'll need it when importing assets from project job to project.
+	"""
+	projectJobId: Int64!
 
-    """
-    The name of the project job.
-    """
-    projectJobName: String!
+	"""
+	The name of the project job.
+	"""
+	projectJobName: String!
 
-    """
-    Project Job type.
-    """
-    projectJobType: ProjectJobType!
+	"""
+	Project Job type.
+	"""
+	projectJobType: ProjectJobType!
 
-    """
-    The status of the project job.
-    """
-    projectJobStatus: ProjectJobStatus!
+	"""
+	The status of the project job.
+	"""
+	projectJobStatus: ProjectJobStatus!
 
-    """
-    Input line count of the upload job.
-    """
-    inputLineCount: Int64
+	"""
+	Input line count of the upload job.
+	"""
+	inputLineCount: Int64
 
-    """
-    Flag on whether or not there are pending staged assets to be imported into the project.
-    """
-    pendingImport: Boolean!
+	"""
+	Flag on whether or not there are pending staged assets to be imported into the project.
+	"""
+	pendingImport: Boolean!
 
-    """
-    The error code of the project job.
-    """
-    errorCode: String
+	"""
+	The error code of the project job.
+	"""
+	errorCode: String
 
-    """
-    The error message of the project job.
-    """
-    errorMessage: String
+	"""
+	The error message of the project job.
+	"""
+	errorMessage: String
 
-    """
-    The date when the job was created.
-    """
-    createdOn: Date!
+	"""
+	The date when the job was created.
+	"""
+	createdOn: Date!
 
-    """
-    The date when the job was updated.
-    """
-    updatedOn: Date!
+	"""
+	The date when the job was updated.
+	"""
+	updatedOn: Date!
 
-    """
-    The user who started the job.
-    """
-    createdBy: User
+	"""
+	The user who started the job.
+	"""
+	createdBy: User
 
-    """
-    The list of staged assets created by this job.
-    """
-    stagedAssetConnection(
-        """
-        Number of records(edges) to return. A number between 0 and 100.
-        """
-        first: Int
+	"""
+	The list of staged assets created by this job.
+	"""
+	stagedAssetConnection(
+		"""
+		Number of records(edges) to return. A number between 0 and 100.
+		"""
+		first: Int
 
-        """
-        Cursor value of a record(edge) past which records should be returned. Cursor can be obtained from an earlier call. Cursor is a string between 10 and 32 characters long.
-        """
-        after: String
+		"""
+		Cursor value of a record(edge) past which records should be returned. Cursor can be obtained from an earlier call. Cursor is a string between 10 and 32 characters long.
+		"""
+		after: String
 
-        """
-        Number of prevous records(edges) to return. A number between 0 and 100.
-        """
-        last: Int
+		"""
+		Number of previous records(edges) to return. A number between 0 and 100.
+		"""
+		last: Int
 
-        """
-        Cursor value of a record(edge) before which records should be returned. Cursor can be obtained from an earlier call. Cursor is a string between 10 and 32 characters long.
-        """
-        before: String
+		"""
+		Cursor value of a record(edge) before which records should be returned. Cursor can be obtained from an earlier call. Cursor is a string between 10 and 32 characters long.
+		"""
+		before: String
 
-        """
-        Filter the connection.
-        """
-        filter: StagedAssetFilter
+		"""
+		Filter the connection.
+		"""
+		filter: StagedAssetFilter
 
-        """
-        Sort order for the connection.
-        """
-        sort: StagedAssetSort
-    ): StagedAssetConnection
+		"""
+		Sort order for the connection.
+		"""
+		sort: StagedAssetSort
+	): StagedAssetConnection
 }
 
 """
 A user of an enterprise group.
 """
 type User {
-    """
-    The user's ID.
-    """
-    id: Int64!
+	"""
+	The user's ID.
+	"""
+	id: Int64!
 
-    """
-    The user's first name.
-    """
-    firstName: String!
+	"""
+	The user's first name.
+	"""
+	firstName: String!
 
-    """
-    The user's last name.
-    """
-    lastName: String!
+	"""
+	The user's last name.
+	"""
+	lastName: String!
 
-    """
-    The user's email address.
-    """
-    email: String!
+	"""
+	The user's email address.
+	"""
+	email: String!
+
+	"""
+	The user's group, if the user belongs to an enterprise group.
+	"""
+	userGroup: UserGroup
+}
+
+type UserGroup {
+	userGroupId: Int!
+	groupName: String!
+	userSubgroups: [UserSubgroup!]
+
+	"""
+	Features enabled for this user group.
+	"""
+	features: [Feature!]
+}
+
+type UserSubgroup {
+	"""
+	The unique identifier of the newly created subgroup.
+	"""
+	userSubgroupId: Int!
+
+	"""
+	The display name of the subgroup.
+	"""
+	subgroupName: String!
+
+	"""
+	The ID of the parent user group under which the subgroup was created.
+	"""
+	userGroupId: Int!
+}
+
+type ValueChainData {
+	"""
+	Name of the value chain position.
+	"""
+	valueChain: String!
+
+	"""
+	Total number of locations within this value chain.
+	"""
+	locationCount: Int64!
+
+	"""
+	Percentage of company's total locations that belong to this value chain.
+	"""
+	locationPercent: Float!
+
+	"""
+	Number of locations within this value chain with a validated geocode (geocode quality score >= 95).
+	"""
+	materialLocationCount: Int64!
+
+	"""
+	Percentage of this value chain's locations that have a validated geocode (geocode quality score >= 95).
+	"""
+	materialLocationPercent: Float!
+
+	"""
+	Total revenue generated by this value chain, calculated as the sum of net operating income (NOI) from all sink locations that receive inputs from this value chain.
+	"""
+	revenue: Int64!
+
+	"""
+	This value chain's revenue as a percentage of the company's total revenue.
+	"""
+	revenuePercent: Float!
+}
+
+enum ValueChainPosition {
+	MANAGEMENT
+	RD
+	PRODUCTION
+	DISTRIBUTION
+	SALES
+}
+
+"""
+Fraction of the company's revenue exposed to climate risk by value chain level
+"""
+type ValueChainRevenueAtRisk {
+	"""
+	Name of the value chain
+	"""
+	valueChainPosition: ValueChainPosition!
+
+	"""
+	Value of revenue at risk
+	"""
+	revenueAtRisk: Float!
+}
+
+"""
+Weights for each value chain position, used to assigning per-location revenue
+"""
+type ValueChainRevenueRealized {
+	"""
+	Name of the value chain
+	"""
+	valueChainPosition: ValueChainPosition!
+
+	"""
+	Value of revenue realized
+	"""
+	revenueRealized: Float!
+}
+
+type ViewedHistoryItem {
+	id: ID!
+
+	"""
+	The placeID if the returned item is one
+	"""
+	placeId: ID
+
+	"""
+	The project ID if the returned item is one
+	"""
+	projectId: ID
+
+	"""
+	Number of assets in the portfolio is the item is one, otherwise 1 if it is a place.
+	"""
+	assetCount: Int64!
+
+	"""
+	The date when the place is last viewed.
+	"""
+	lastViewed: Date!
+
+	"""
+	Display name for the history item. For places, the address. For assets in a project, the building descriptor. For projects/portfolios, the company or project name.
+	"""
+	name: String
+
+	"""
+	Item classification. Null for place-only items and unknown projects.
+	"""
+	type: ViewedHistoryItemType
+}
+
+"""
+Classifies a ViewedHistoryItem. Combines PortfolioType and ProjectAssetClass,
+plus PLACE for a bare place and REAL_ESTATE_ASSET for an REA (a place inside a portfolio).
+"""
+enum ViewedHistoryItemType {
+	"""
+	A bare place (placeId only, no project).
+	"""
+	PLACE
+
+	"""
+	A real estate asset (place within a portfolio).
+	"""
+	REAL_ESTATE_ASSET
+
+	"""
+	A real estate portfolio (REP).
+	"""
+	REAL_ESTATE_PORTFOLIO
+
+	"""
+	A mixed portfolio.
+	"""
+	MIXED_PORTFOLIO
+
+	"""
+	A publicly visible company project.
+	"""
+	COMPANY
+
+	"""
+	A NonREA company project.
+	"""
+	COMPANY_ASSET
+
+	"""
+	A NonREA linear project.
+	"""
+	LINEAR_ASSET
+
+	"""
+	A NonREA area project.
+	"""
+	AREA_ASSET
+}
+
+type ViewedHistoryList {
+	"""
+	List of ViewedItems items.
+	"""
+	viewedHistoryItems: [ViewedHistoryItem!]!
+}
+
+enum ViewedItemsSort {
+	TIMESTAMP_ASC
+	TIMESTAMP_DESC
 }
 
 type ViewedPlace implements Node {
-    id: ID!
+	id: ID!
 
-    """
-    The description of the place.
-    """
-    descriptor: String
+	"""
+	The description of the place.
+	"""
+	descriptor: String
 
-    """
-    The place's building details.
-    """
-    building: EnterpriseBuilding
+	"""
+	The place's building details.
+	"""
+	building: EnterpriseBuilding
 
-    """
-    The place's ID.
-    """
-    placeId: String!
+	"""
+	The place's ID.
+	"""
+	placeId: String!
 
-    """
-    The date and time when the place was last viewed.
-    """
-    lastViewed: Date!
+	"""
+	The date and time when the place was last viewed.
+	"""
+	lastViewed: Date!
 }
 
 type ViewedPlacesConnection {
-    """
-    Returns a list of ViewedPlacesEdge. Each edge contains a cursor and the node.
-    """
-    edges: [ViewedPlacesEdge!]!
+	"""
+	Returns a list of ViewedPlacesEdge. Each edge contains a cursor and the node.
+	"""
+	edges: [ViewedPlacesEdge!]!
 
-    """
-    Contains pagination information in relation to the current page.
-    """
-    pageInfo: PageInfo!
+	"""
+	Contains pagination information in relation to the current page.
+	"""
+	pageInfo: PageInfo!
 
-    """
-    Total number of records for the connection.
-    """
-    totalCount: Int64
+	"""
+	Total number of records for the connection.
+	"""
+	totalCount: Int64
 }
 
 type ViewedPlacesEdge {
-    """
-    Cursor is a string that can be used in subsequent request as value of a connection "after" argument, to request page starting after this item.
+	"""
+	Cursor is a string that can be used in subsequent request as value of a connection "after" argument, to request page starting after this item.
 
-    Example: *Y3Vyc29yOjEyNTI0MA==*
-    """
-    cursor: String
+	Example: *Y3Vyc29yOjEyNTI0MA==*
+	"""
+	cursor: String
 
-    """
-    Contains one page record data.
-    """
-    node: ViewedPlace!
+	"""
+	Contains one page record data.
+	"""
+	node: ViewedPlace!
 }
 
 enum ViewedPlacesSort {
-    TIMESTAMP_ASC
-    TIMESTAMP_DESC
+	TIMESTAMP_ASC
+	TIMESTAMP_DESC
 }
 
 enum WindDesignStandard {
-    LOW
-    MEDIUM
-    HIGH
+	LOW
+	MEDIUM
+	HIGH
+}
+
+type WindExposureStatistics {
+	"""
+	Socio-economic pathway of the prediction model.
+	"""
+	ssp: SSP!
+
+	"""
+	The relative year with current year being year 0.
+	"""
+	relativeYear: Int64!
+
+	"""
+	The return period.
+	"""
+	returnPeriod: ReturnPeriod
+
+	"""
+	The wind speed threshold in miles per hour.
+	"""
+	windSpeedThresholdMph: Int64!
+
+	"""
+	Maximum 3-second wind gust speed in a portfolio at the given probability / SSP / Year
+	"""
+	maxSpeedMph: Int64!
+
+	"""
+	Average 3-second wind gust speed in a portfolio at the given probability / SSP / Year
+	"""
+	avgSpeedMph: Int64!
+
+	"""
+	Number of assets exposed to 3-second wind gust speeds above [windSpeedThresholdMph] in the given scenario
+	"""
+	countWind: Int64!
+
+	"""
+	Percentage of assets exposed to 3-second wind gust speeds above [windSpeedThresholdMph] in the given scenario
+	"""
+	pctWind: Float!
 }

--- a/enterprise-api/schema.graphql
+++ b/enterprise-api/schema.graphql
@@ -1460,9 +1460,19 @@ enum AssetTypeId {
 	N9
 
 	"""
+	INFRASTRUCTURE – Energy – Battery Storage
+	"""
+	NB
+
+	"""
 	INFRASTRUCTURE – Utilities – Fiber-Optic Networks
 	"""
 	NF
+
+	"""
+	INFRASTRUCTURE – Energy – Pipelines (Oil, Gas) - Gate Station
+	"""
+	NG
 
 	"""
 	INFRASTRUCTURE – Transportation – Roads & Highways
@@ -1475,7 +1485,17 @@ enum AssetTypeId {
 	NI
 
 	"""
-	INFRASTRUCTURE – Transportation – Pipelines (Oil, Gas, Water)
+	INFRASTRUCTURE – Transportation – Light Rail
+	"""
+	NL
+
+	"""
+	INFRASTRUCTURE – Transportation – Tunnel
+	"""
+	NN
+
+	"""
+	INFRASTRUCTURE – Energy – Pipelines (Oil, Gas, Water)
 	"""
 	NP
 
@@ -1495,9 +1515,29 @@ enum AssetTypeId {
 	NS
 
 	"""
+	INFRASTRUCTURE – Energy – Substation
+	"""
+	NT
+
+	"""
 	INFRASTRUCTURE – Transportation – Urban Transit
 	"""
 	NU
+
+	"""
+	INFRASTRUCTURE – Transportation – Container & Cargo Ports
+	"""
+	NV
+
+	"""
+	INFRASTRUCTURE – Energy – Transmission Tower
+	"""
+	NW
+
+	"""
+	INFRASTRUCTURE – Transportation – Airport Runways
+	"""
+	NY
 
 	"""
 	OFFICE - Urban / Low-Rise (1-4 stories)
@@ -2415,19 +2455,23 @@ type Coordinate {
 	locality: AssetLocality
 }
 
+"""
+Input type for portfolio copy.
+"""
 input CopyPortfolioToNewParentInput {
 	"""
-	New parent portfolio ID of the portfolio to be cloned.
+	The new parent portfolio ID.
 	"""
 	targetParentPortfolioId: Int64!
 
 	"""
-	ID of the portfolio to be cloned
+	ID of the portfolio to be copied.
 	"""
 	portfolioId: Int64!
 
 	"""
-	The new project name. If omitted the cloned project name will be based off the original portfolio name.
+	An optional name to be assigned to the new portfolio, if a new portfolio is created in this operation.
+	The system will use a random-generated unique name if omitted.
 	"""
 	projectName: String
 }
@@ -2517,6 +2561,11 @@ input CreateProjectJobUploadLinkInput {
 	Custom headers to add to the uploaded file metadata. For internal use only.
 	"""
 	customHeaders: [ProjectUploadHeadersInput]
+
+	"""
+	Optional payload-type discriminator. When COMPANY, GEOJSON is not accepted. Default REA.
+	"""
+	uploadType: ProjectUploadType
 }
 
 """
@@ -2633,6 +2682,9 @@ type DeleteCustomBuildingValuesPayload {
 	success: Boolean!
 }
 
+"""
+Input type for portfolio deletion.
+"""
 input DeletePortfolioFromParentInput {
 	"""
 	ID of the portfolio to be removed
@@ -2744,16 +2796,16 @@ input DeleteUserGroupStagedAdaptationsInput {
 }
 
 """
-A sub-portfolio in the subtree that has a dirty status, with its depth level.
+A subportfolio in the portfolio hierarchy that has a dirty status, with its depth level.
 """
 type DirtySubportfolio {
 	"""
-	The project ID of the dirty sub-portfolio.
+	The project ID of the dirty subportfolio.
 	"""
 	projectId: Int64!
 
 	"""
-	The depth level in the tree rooted at the queried portfolio.
+	The depth level in the hierarchy rooted from the queried portfolio.
 	Level 1 = direct child, level 2 = grandchild, etc.
 	"""
 	level: Int!
@@ -4993,7 +5045,7 @@ type Mutation {
 	updateProject(input: UpdateProjectInput!): Project!
 
 	"""
-	Update asset details for a project within a portfolio. Only valid for asset-type projects.
+	Update asset details for a LINEAR/AREA/COMPANY asset.
 	"""
 	updatePortfolioAssetDetails(
 		input: UpdatePortfolioAssetDetailsInput!
@@ -5046,6 +5098,13 @@ type Mutation {
 		projectJobId: Int64!
 		pendingImport: Boolean!
 	): UploadJob!
+
+	"""
+	Set the value chain revenue overrides for a company upload job. Idempotent: replaces the previous map for this projectJobId.
+	"""
+	setValueChainRevenue(
+		input: SetValueChainRevenueInput!
+	): SetValueChainRevenuePayload!
 
 	"""
 	Set user's portfolio custom building details for a specific place.
@@ -5147,7 +5206,6 @@ type Mutation {
 	Generate a link share for a place on ePDP, an entire project, or a place in a project.
 	"""
 	generateLinkShare(input: GenerateLinkShareInput!): GenerateLinkSharePayload!
-	linkShare(linkId: String!): LinkShare
 	updateLinkShare(input: UpdateLinkShareInput!): UpdateLinkSharePayload!
 
 	"""
@@ -5156,68 +5214,74 @@ type Mutation {
 	deleteViewedHistoryItem(input: EntDeleteViewedHistoryInput!): RequestStatus!
 
 	"""
-	Save a place or portfolio to the recently viewed items list for the current user.
+	Save a visited asset, portfolio, place with no portfolio, or publicly available company to the recently viewed history for the current user.
 	"""
 	saveViewedHistoryItem(input: SaveViewHistoryInput!): SaveViewHistoryPayload!
 
 	"""
-	Assign a portfolio to a new parent portfolio.
+	Move a portfolio to a new parent portfolio.
 	"""
 	movePortfolio(input: UpdatePortfolioParentInput!): RequestStatus!
 
 	"""
-	Delete a portfolio that is the child of another portfolio.
+	Remove a portfolio including its entire hierarchy from the parent portfolio.
+	The data for the entire hierarchy will be deleted.
 	"""
 	removePortfolioFromParent(
 		input: DeletePortfolioFromParentInput!
 	): RequestStatus!
 
 	"""
-	Assign a new parent to an REA.
+	Move a REAL_ESTATE asset to a new parent portfolio.
 	"""
-	moveREAToNewParent(input: UpdateREAParentInput!): CreateProjectAssetPayload!
+	moveRealEstateAssetToNewParent(
+		input: UpdateRealEstateAssetParentInput!
+	): CreateProjectAssetPayload!
 
 	"""
-	Create a copy of an REA and assign it to a new parent.
+	Copy of a REAL_ESTATE asset and assign it to a new parent.
 	"""
-	copyREAToNewParent(input: UpdateREAParentInput!): CreateProjectAssetPayload!
+	copyRealEstateAssetToNewParent(
+		input: UpdateRealEstateAssetParentInput!
+	): CreateProjectAssetPayload!
 
 	"""
-	Delete an REA that is the child of a portfolio.
+	Delete a REAL_ESTATE asset from its parent portfolio.
 	"""
-	deleteREAFromParent(input: DeleteProjectAssetInput!): RequestStatus
+	deleteRealEstateAssetFromParent(
+		input: DeleteProjectAssetInput!
+	): RequestStatus
 
 	"""
-	Create a copy of a portfolio and assign it to a new parent.
+	Copy a portfolio with its entire hierarchy and assign it to a new parent.
 	"""
 	copyPortfolioToNewParent(
 		input: CopyPortfolioToNewParentInput!
 	): CopyPortfolioToNewParentPayload!
 
 	"""
-	Move a portfolio asset to a new parent.
+	Move a non-real-estate asset (LINEAR/AREA/COMPANY asset) to a new parent.
 	"""
-	movePortfolioAssetToNewParent(
+	moveNonRealEstateAssetToNewParent(
 		input: UpdatePortfolioParentInput!
 	): RequestStatus!
 
 	"""
-	Creat a copy of a portfolio asset and assign it to a new parent.
+	Copy a non-real-estate asset (LINEAR/AREA/COMPANY asset) and assign it to a new parent.
 	"""
-	copyPortfolioAssetToNewParent(
+	copyNonRealEstateAssetToNewParent(
 		input: UpdatePortfolioParentInput!
 	): ProjectClonePayload!
 
 	"""
-	Delete a portfolio asset from its portfolio.
+	Remove a non-real-estate asset (LINEAR/AREA/COMPANY asset) from its parent portfolio. The data for this asset will be deleted.
 	"""
-	removePortfolioAssetFromParent(
+	removeNonRealEstateAssetFromParent(
 		input: DeletePortfolioFromParentInput!
 	): RequestStatus!
 
 	"""
-	Refresh a portfolio's data by triggering a refresh job.
-	The portfolio will appear in PROCESSING status while there is an unfinished PORTFOLIO_REFRESH job
+	Run portfolio refresh to update report data for all portfolios in the hierarchy including itself.
 	"""
 	refreshPortfolio(input: RefreshPortfolioInput!): RequestStatus!
 }
@@ -5305,83 +5369,86 @@ type PerilBucketDistribution {
 }
 
 """
-A portfolio view combining the portfolio's own info with its paginated children.
+A portfolio view combining the portfolio metadata with its children in the hierarchy.
 """
 type Portfolio {
 	"""
-	Portfolio Id, which is also known as project id
+	Portfolio Id, also known as project id.
 	"""
 	projectId: Int64
 
 	"""
-	Name of the portfolio
+	Name of the portfolio.
 	"""
 	name: String
 
 	"""
-	Portfolio type, can be either Mixed or Real Estate
+	Portfolio type, can be either MIXED or REAL_ESTATE.
 	"""
 	portfolioType: PortfolioType
 
 	"""
-	Parent portfolio Id
+	Parent portfolio Id.
 	"""
 	parentProjectId: Int64
 
 	"""
-	Portfolio investment stage, either holding or acquisition
+	Portfolio investment stage, either HOLDING or ACQUISITION.
 	"""
 	investmentStage: InvestmentStage
 
 	"""
-	Current status of the portfolio, indicating whether the data is updated, in processing, or dirty
+	Current status of the portfolio, indicating whether the data is UPDATED, in PROCESSING, or DIRTY.
+	A DIRTY portfolio means there are changes in the hierarchy rooted at the portfolio and that it needs a portfolio refresh.
 	"""
 	portfolioStatus: PortfolioStatus
 
 	"""
-	Portfolio creation date
+	Portfolio creation date.
 	"""
 	createdAt: Date
 
 	"""
-	Number of assets including RealEstate, company, linear, or area assets
+	Number of assets including REAL_ESTATE/LINEAR/AREA/COMPANY assets.
 	"""
 	assetCount: Int64
 
 	"""
-	Number of sub portfolios in the hierarchy
+	Number of subportfolios in the hierarchy.
 	"""
 	portfolioCount: Int64
 
 	"""
-	Portfolio's subgroup id
+	Portfolio's subgroup id.
 	"""
 	subGroupId: Int
 
 	"""
-	Filter contents available in the portfolio hierarchy
+	The values that can be applied to a portfolio report.
+	The values are extracted from the entire portfolio hierarchy.
 	"""
 	portfolioFilterContent: PortfolioFilterContent
 
 	"""
-	The direct children of this portfolio (REAs, non-REA assets, and sub-portfolios).
+	The direct children of the portfolio, can be REAL_ESTATE/LINEAR/AREA/COMPANY assets and subportfolios.
 	"""
 	descendants(input: PortfolioContentsInput): PortfolioContentConnection!
 
 	"""
-	Dashboard scores for this portfolio, with optional filtering.
+	Portfolio report peril aggregated scores for this portfolio with filters.
+	The aggregation covers all assets and subportfolios from the hierarchy.
 	"""
 	portfolioDashboardScores(
 		filter: DashboardScoreFilter
 	): [PortfolioDashboardScore]
 
 	"""
-	Maps for the portfolio.
+	The map for the entire portfolio hierarchy.
 	"""
 	map: PortfolioMap
 
 	"""
-	All sub-portfolios in the subtree that have a dirty status, with their tree level.
+	All DIRTY subportfolios' metadata in the entire hierarchy.
 	"""
 	dirtySubportfolios: [DirtySubportfolio!]
 }
@@ -5396,31 +5463,38 @@ type PortfolioAssetDetails {
 }
 
 """
-Represents a content item within a portfolio - can be an REA, non-REA asset, or sub-portfolio.
+A portfolio contents represents a descendant item within a portfolio hierarchy - can be a REAL_ESTATE/LINEAR/AREA/COMPANY asset or subportfolios.
 """
 type PortfolioContent {
 	"""
-	The project ID. For REAs, this is the parent project ID. For non-REA assets and sub-portfolios, this is their own project ID.
+	The project ID.
+	For REAL_ESTATE assets, this is the parent project ID.
+	For LINEAR/AREA assets and subportfolios, this is their own project ID.
 	"""
 	projectId: Int64!
 
 	"""
-	The place ID. Only set for REAs (real estate assets).
+	The place ID. Only set for REAL_ESTATE assets.
 	"""
 	placeId: String
 
 	"""
-	The name of the content item. For REAs, this is building.customid. For projects, this is company.name.
+	The name of the portfolio descendant item.
+	For REAL_ESTATE assets, this is building.customid.
+	For LINEAR/AREA assets, this is the name of the project.
+	For company this is either the project name or fallback to company name.
 	"""
 	name: String!
 
 	"""
-	The asset class. Values: "company", "linear", "area". Null for REPs and sub-portfolios.
+	The asset class. Values: REAL_ESTATE, COMPANY, LINEAR, AREA.
+	Only assets will have assetClass, Real estate portfolios and sub-portfolios will have null for this field.
 	"""
 	assetClass: ProjectAssetClass
 
 	"""
-	The portfolio type. Values: "Mixed", "RealEstate". Null for assets including REAs and company / linear / area assets.
+	The portfolio type. Values: MIXED, REAL_ESTATE.
+	Only portfolios will have portfolioType, assets will have this field null.
 	"""
 	portfolioType: PortfolioType
 
@@ -5450,7 +5524,7 @@ type PortfolioContent {
 	createdAt: Date!
 
 	"""
-	Total number of assets in the subtree (including self). For portfolios: REAs + company/linear/area in entire subtree. For leaf items: 1.
+	Total number of assets in the entire portfolio hierarchy, including REAL_ESTATE/LINEAR/AREA/COMPANY assets.
 	"""
 	assetCount: Int64
 
@@ -6152,7 +6226,7 @@ Project asset class - categorizes the class of assets in a project.
 """
 enum ProjectAssetClass {
 	"""
-	Real estate assets (properties).
+	Real estate assets, properties that can be residential rentals, Commercial property, industrial real estate, etc.
 	"""
 	REAL_ESTATE
 
@@ -6162,7 +6236,7 @@ enum ProjectAssetClass {
 	COMPANY
 
 	"""
-	Linear assets (pipelines, roads, etc.).
+	Linear assets, can be pipelines, roads, etc.
 	"""
 	LINEAR
 
@@ -7179,6 +7253,26 @@ input ProjectUploadHeadersInput {
 	value: String!
 }
 
+"""
+The kind of payload an upload contains.
+"""
+enum ProjectUploadType {
+	"""
+	Real-estate asset upload (default).
+	"""
+	REA
+
+	"""
+	Company Portfolio Creator (CPC) upload — equity portfolio with FS-managed company assets.
+	"""
+	CPC
+
+	"""
+	Customer-company upload.
+	"""
+	COMPANY
+}
+
 type ProjectsConnection {
 	"""
 	The total number of edges in the connection.
@@ -7264,6 +7358,13 @@ type Query {
 	Get project job by id
 	"""
 	projectJob(projectJobId: Int64!): ProjectJob
+
+	"""
+	Get the staged value chain revenue overrides for a company upload job.
+	Returns the list previously persisted via setValueChainRevenue, or an
+	empty list if none has been set.
+	"""
+	valueChainRevenue(projectJobId: Int64!): [ValueChainRevenue!]!
 
 	"""
 	Get all the project jobs the session user has access to.
@@ -7395,7 +7496,7 @@ type Query {
 	): LinkSharesConnection
 
 	"""
-	Get the full ancestor path from root to the given project, ordered root-to-leaf.
+	Get the full ancestor portfolio path from root to the given project, ordered root-to-leaf.
 	"""
 	portfolioPath(projectId: Int64!): [PortfolioPathNode!]!
 
@@ -7405,12 +7506,28 @@ type Query {
 	userGroup: UserGroup
 
 	"""
-	Get a portfolio with its own info and paginated descendants in a single call.
+	Get portfolio metadata with descendants
 	"""
 	portfolio(input: PortfolioInput): Portfolio!
+
+	"""
+	List all available industries.
+	"""
+	lookupIndustries: [Industry!]!
+
+	"""
+	List all available sectors.
+	"""
+	lookupSectors: [Sector!]!
 }
 
+"""
+Input type for portfolio refresh.
+"""
 input RefreshPortfolioInput {
+	"""
+	ID of the portfolio to be refreshed
+	"""
 	portfolioId: Int64!
 }
 
@@ -7798,6 +7915,21 @@ type Sector {
 }
 
 """
+Input for setValueChainRevenue. The full revenue map for an upload job is replaced on each call.
+"""
+input SetValueChainRevenueInput {
+	projectJobId: Int64!
+	valueChainRevenue: [ValueChainRevenueEntry!]!
+}
+
+"""
+Result of setValueChainRevenue.
+"""
+type SetValueChainRevenuePayload {
+	success: Boolean!
+}
+
+"""
 Severity
 """
 enum Severity {
@@ -8089,6 +8221,21 @@ type StagedAsset {
 	The geocode quality score of the asset from company data or geocoder
 	"""
 	geocodeQualityScore: Int
+
+	"""
+	Customer-supplied location revenue in US dollars. Populates the asset's NOI on import.
+	"""
+	locationRevenue: Int64
+
+	"""
+	Value chain positions declared for this asset. This field may be null when not applicable, including for non-customer-company uploads.
+	"""
+	valueChainPositions: [ValueChainPosition!]
+
+	"""
+	True when this asset is the company's headquarters. Exactly one asset per customer company upload must have this set.
+	"""
+	isHeadquarters: Boolean
 }
 
 """
@@ -8229,19 +8376,23 @@ input UpdatePortfolioAssetDetailsInput {
 	bookValue: Int64
 }
 
+"""
+Input type for portfolio related move or copy.
+"""
 input UpdatePortfolioParentInput {
 	"""
-	New parent portfolio ID of the portfolio to be moved.
+	The new parent portfolio ID.
 	"""
 	targetParentPortfolioId: Int64!
 
 	"""
-	ID of the portfolio to be moved
+	ID of the portfolio to be processed.
 	"""
 	portfolioId: Int64!
 
 	"""
-	Optional new project name to use when this input is used for copy/clone operations.
+	An optional name to be assigned to the new portfolio, if a new portfolio is created in this operation.
+	The system will use a random-generated unique name if omitted.
 	"""
 	projectName: String
 }
@@ -8352,19 +8503,22 @@ type UpdateProjectStagedCustomBuildingValuesPayload {
 	stagedBuilding: EnterpriseBuilding
 }
 
-input UpdateREAParentInput {
+"""
+Input type for REAL_ESTATE asset move or copy.
+"""
+input UpdateRealEstateAssetParentInput {
 	"""
-	Target parent portfolio ID of the portfolio to be moved.
+	The new parent portfolio ID.
 	"""
 	targetParentPortfolioId: Int64!
 
 	"""
-	Current portfolio ID of the asset
+	The current parent portfolio ID.
 	"""
 	currentParentPortfolioId: Int64!
 
 	"""
-	Place ID of the projectAsset to be moved
+	Place ID of the REAL_ESTATE asset to be moved or copied.
 	"""
 	placeId: String!
 }
@@ -8474,6 +8628,11 @@ type UploadJob implements ProjectJob {
 		"""
 		sort: StagedAssetSort
 	): StagedAssetConnection
+
+	"""
+	The kind of payload this upload job carries (set when the upload was created with an explicit uploadType).
+	"""
+	uploadType: ProjectUploadType
 }
 
 """
@@ -8580,6 +8739,16 @@ enum ValueChainPosition {
 }
 
 """
+A persisted value chain position with its assigned revenue (in USD whole
+dollars). Output mirror of ValueChainRevenueEntry, returned by the
+valueChainRevenue query.
+"""
+type ValueChainRevenue {
+	valueChainPosition: ValueChainPosition!
+	revenue: Int64!
+}
+
+"""
 Fraction of the company's revenue exposed to climate risk by value chain level
 """
 type ValueChainRevenueAtRisk {
@@ -8592,6 +8761,14 @@ type ValueChainRevenueAtRisk {
 	Value of revenue at risk
 	"""
 	revenueAtRisk: Float!
+}
+
+"""
+A single value chain position with its assigned revenue (in USD whole dollars).
+"""
+input ValueChainRevenueEntry {
+	valueChainPosition: ValueChainPosition!
+	revenue: Int64!
 }
 
 """
@@ -8644,8 +8821,9 @@ type ViewedHistoryItem {
 }
 
 """
-Classifies a ViewedHistoryItem. Combines PortfolioType and ProjectAssetClass,
-plus PLACE for a bare place and REAL_ESTATE_ASSET for an REA (a place inside a portfolio).
+Classifies a ViewedHistoryItem.
+A ViewedHistoryItem can be created from recently viewed portfolios, assets,
+places having no portfolios, and public-facing companies.
 """
 enum ViewedHistoryItemType {
 	"""
@@ -8659,7 +8837,7 @@ enum ViewedHistoryItemType {
 	REAL_ESTATE_ASSET
 
 	"""
-	A real estate portfolio (REP).
+	A real estate portfolio.
 	"""
 	REAL_ESTATE_PORTFOLIO
 
@@ -8674,17 +8852,17 @@ enum ViewedHistoryItemType {
 	COMPANY
 
 	"""
-	A NonREA company project.
+	A company asset project.
 	"""
 	COMPANY_ASSET
 
 	"""
-	A NonREA linear project.
+	A linear asset project.
 	"""
 	LINEAR_ASSET
 
 	"""
-	A NonREA area project.
+	An area asset project.
 	"""
 	AREA_ASSET
 }


### PR DESCRIPTION
# Changelog — Enterprise API (v2026.19)

This release is a major expansion of the First Street Enterprise GraphQL API. The feature surface roughly doubles: the schema introduces full **Portfolio**, **Locality**, **Adaptation**, **Asset Valuation / Value Chain**, **Macroeconomic**, **Link Sharing**, and **AI Insights** domains, alongside a new **Hazard** rollup peril and substantially expanded damage outputs (interruption loss, cash loss, operator loss) on Flood and Wind.

There are no removed types, queries, mutations, or enum values in this release. All listed deprecations are soft — the deprecated fields continue to function, but new code should adopt the replacements documented below.

---

## Breaking changes

There are **no hard breaking changes** in this release. No types, fields, enum values, queries, or mutations were removed. No field types or required‑ness were changed.

A few notes on changes you may notice:

- The schema file was reformatted (4‑space indentation to tabs). This is cosmetic only and has no effect on the API contract.
- Several previously unique sort/factor names now sit alongside new `*_SCORE_*` and `*_HAZARD_*` variants. Existing values still work.
- The deprecated‑but‑still‑functional fields below should be migrated within this release cycle; they are scheduled for removal in a future major release.

---

## Deprecations

These items still work but should be migrated.

### Climate factor scalars → granular `factorScore`

On every `AssetClimateExposure*` type, the single integer `*Factor` and `factorScale` fields are replaced by `factorScore(filterBy: AssetSortFilter): [FactorScore]`, which exposes score and scale broken down by SSP and year.

- `AssetClimateExposureCold.coldFactor` → `factorScore.score`
- `AssetClimateExposureCold.factorScale` → `factorScore.scale`
- `AssetClimateExposureDrought.droughtFactor` / `factorScale` → `factorScore.score` / `factorScore.scale`
- `AssetClimateExposureFlood.floodFactor` / `factorScale` → `factorScore.score` / `factorScore.scale`
- `AssetClimateExposureHeat.heatFactor` / `factorScale` → `factorScore.score` / `factorScore.scale`
- `AssetClimateExposureWildfire.fireFactor` / `factorScale` → `factorScore.score` / `factorScore.scale`
- `AssetClimateExposureWind.windFactor` / `factorScale` → `factorScore.score` / `factorScore.scale`

### `AssetSort` factor enums → `*_SCORE_*` variants

The following sort values are deprecated; use the `_SCORE_` variants which sort on `factorScore.score`:

- `CLIMATE_EXPOSURE_FLOOD_FACTOR_ASC` / `_DESC` → `CLIMATE_EXPOSURE_FLOOD_FACTOR_SCORE_ASC` / `_DESC`
- `CLIMATE_EXPOSURE_FIRE_FACTOR_ASC` / `_DESC` → `CLIMATE_EXPOSURE_FIRE_FACTOR_SCORE_ASC` / `_DESC`
- `CLIMATE_EXPOSURE_WIND_FACTOR_ASC` / `_DESC` → `CLIMATE_EXPOSURE_WIND_FACTOR_SCORE_ASC` / `_DESC`
- `CLIMATE_EXPOSURE_HEAT_FACTOR_ASC` / `_DESC` → `CLIMATE_EXPOSURE_HEAT_FACTOR_SCORE_ASC` / `_DESC`
- `CLIMATE_EXPOSURE_COLD_FACTOR_ASC` / `_DESC` → `CLIMATE_EXPOSURE_COLD_FACTOR_SCORE_ASC` / `_DESC`
- `CLIMATE_EXPOSURE_DROUGHT_FACTOR_ASC` / `_DESC` → `CLIMATE_EXPOSURE_DROUGHT_FACTOR_SCORE_ASC` / `_DESC`

### Project & query deprecations

- `Query.projects` → use `Query.projectsConnection` for pagination, sort, and filter support.
- `Query.projectJobs` → redundant; use `Query.projectJobsConnection`.
- `Query.projectAutocomplete` → marked WIP; do not depend on it.
- `Mutation.deleteProject` → replaced by `Mutation.deleteProjectAsync`, which returns a `ProjectJob` and runs as a background job.
- `Project.vintage: String!` → replaced by `Project.vintageId: Int64` (numeric for consistency).
- `ProjectAssetAdaptation.relativeYear` → use `holdPeriod` instead.

### Macroeconomic / company

- `Company.industryId` → `Company.industry.id` (new `Industry` object).
- `Company.sectorId` → `Company.sector.id` (new `Sector` object).
- The following macroeconomic factor fields are now obsolete (marked `@deprecated`): `econFactorClimate`, `econFactorScaleClimate`, `gdpChangeFactor`, `gdppcChangeFactor`, `medianAgeChangeFactor`, `nativeBornPctChangeFactor`, `populationChangeFactor`, `rppiChangeFactor`, `cppiChangeFactor`, `unemploymentChangeFactor`.

---

## New features and additions

### Adaptation (new domain)

- New types: `Adaptation`, `AdaptationSummaryData`, `ModuleAdaptation`, `ModuleAdaptationSummary`, `ProjectAdaptationData`, `ProjectAdaptationSummaryData`, `ProjectAssetAdaptation`, `ProjectAssetAdaptationConnection`, `ProjectAssetAdaptationEdge`, `StagedAdaptation`.
- New enums: `AdaptationType` (FLOOD_BARRIER_TO_1_FOOT … _8_FEET, FIRE_PROOFING, DEFENSIBLE_SPACE, WIND_DESIGN_STANDARD_LOW_TO_MEDIUM / _MEDIUM_TO_HIGH / _LOW_TO_HIGH, ROOF_TYPE_TO_METAL), `ProjectAssetAdaptationSort`.
- New inputs: `AdaptationsInput`, `ProjectAdaptationPlanItem`, `ProjectAssetAdaptationFilter`, `ProjectStagedAdaptationsInput`, `StagedAdaptationInput`, `UpdateProjectStagedAdaptationsInput`, `UpdateProjectStagedAdaptationsPlanInput`, `UpdateUserGroupStagedAdaptationsInput`, `DeleteUserGroupStagedAdaptationsInput`.
- New queries: `userGroupStagedAdaptations(placeId: String!): [StagedAdaptation]!`, `projectStagedAdaptations(input: ProjectStagedAdaptationsInput!): [StagedAdaptation]!`.
- New mutations: `updateUserGroupStagedAdaptations`, `deleteUserGroupStagedAdaptations`, `updateProjectStagedAdaptations`, `updateProjectStagedAdaptationsPlan`.

### Locality (new domain)

- New types: `Locality`, `AssetLocality`, `ParentLocality`, `ModuleLocality`, `LocalityMacroeconomicData`, `ProjectLocalityData`, `ProjectLocalityExposure`, `ProjectLocalityExposureConnection`, `ProjectLocalityExposureEdge`, `ProjectLocalitiesPayload`.
- New enums: `AdministrativeLevel` (`ADMIN_0`, `ADMIN_1`, `ADMIN_2`, `METRO`), `ProjectLocalityExposureSort`.
- New inputs: `LocalityFilter`, `LocalityExportInput`, `LocalityExportAssetsFilter`, `ProjectLocalitiesInput`, `ProjectLocalityExposureFilter`.
- New query: `projectLocalities(input: ProjectLocalitiesInput!): ProjectLocalitiesPayload!`.
- New mutation: `createLocalityMacroeconomicExport(input: LocalityExportInput!): ExportJob!`.
- `ProjectAssetFilter` adds `localityFilter` and `localityFilters` fields.
- `AssetSortFilter` adds an `adminLevel: AdministrativeLevel` field.
- `ProjectAsset` adds a `locality: AssetLocality` field.

### Portfolio (new domain)

- New types: `Portfolio`, `PortfolioContent`, `PortfolioContentConnection`, `PortfolioContentEdge`, `PortfolioFilterContent`, `PortfolioPathNode`, `PortfolioMap`, `PortfolioAssetDetails`, `PortfolioDashboardScore`, `PortfolioPerilScore`, `DirtySubportfolio`, `CopyPortfolioToNewParentPayload`.
- New enums: `PortfolioContentSort`, `PortfolioContentType`, `PortfolioStatus`, `PortfolioType`.
- New inputs: `PortfolioInput`, `PortfolioContentsInput`, `CopyPortfolioToNewParentInput`, `DeletePortfolioFromParentInput`, `RefreshPortfolioInput`, `UpdatePortfolioAssetDetailsInput`, `UpdatePortfolioParentInput`, `DashboardScoreFilter`, `UpdateRealEstateAssetParentInput`.
- New queries: `portfolio(input: PortfolioInput): Portfolio!`, `portfolioPath(projectId: Int64!): [PortfolioPathNode!]!`.
- New mutations: `updatePortfolioAssetDetails`, `movePortfolio`, `removePortfolioFromParent`, `copyPortfolioToNewParent`, `moveRealEstateAssetToNewParent`, `copyRealEstateAssetToNewParent`, `deleteRealEstateAssetFromParent`, `moveNonRealEstateAssetToNewParent`, `copyNonRealEstateAssetToNewParent`, `removeNonRealEstateAssetFromParent`, `refreshPortfolio`.

### Asset Valuation & Value Chain (new domain)

- New types: `AssetValueChain`, `ValueChainData`, `ValueChainRevenueAtRisk`, `ValueChainRevenueRealized`, `RisksByValueChainData`, `ValueChainRevenue`, `SetValueChainRevenuePayload`.
- New enums: `ValueChainPosition`, `ProjectAssetClass`.
- New inputs: `ValueChainRevenueEntry`, `SetValueChainRevenueInput`.
- `ProjectAssetFilter` adds `valueChainPosition: [ValueChainPosition!]`.
- `ProjectAsset` adds `valuechain: AssetValueChain`.
- New query: `valueChainRevenue(projectJobId: Int64!): [ValueChainRevenue!]!` — returns the staged value chain revenue overrides for a company upload job.
- New mutation: `setValueChainRevenue(input: SetValueChainRevenueInput!): SetValueChainRevenuePayload!` — idempotently replaces the full value chain revenue map for a company upload job.

### Upload payload typing

- New enum: `ProjectUploadType` (`REA`, `CPC`, `COMPANY`).
- `CreateProjectJobUploadLinkInput` adds `uploadType: ProjectUploadType` (defaults to `REA`; `COMPANY` uploads do not accept GeoJSON).
- `UploadJob` adds `uploadType: ProjectUploadType`.
- `StagedAsset` adds `locationRevenue: Int64`, `valueChainPositions: [ValueChainPosition!]`, and `isHeadquarters: Boolean` to support customer-company uploads (exactly one HQ per company upload).

### Industry / Sector lookups

- New queries: `lookupIndustries: [Industry!]!`, `lookupSectors: [Sector!]!` for populating filter pickers.

### Asset type catalog (`AssetTypeId`)

New infrastructure asset type codes:

- `NB` — Energy – Battery Storage
- `NG` — Energy – Pipelines (Oil, Gas) - Gate Station
- `NL` — Transportation – Light Rail
- `NN` — Transportation – Tunnel
- `NT` — Energy – Substation
- `NV` — Transportation – Container & Cargo Ports
- `NW` — Energy – Transmission Tower
- `NY` — Transportation – Airport Runways

`NP` is reclassified from `Transportation – Pipelines (Oil, Gas, Water)` to `Energy – Pipelines (Oil, Gas, Water)`. Value and meaning of the code are unchanged; only the human-readable category label moved.

### Custom building values & staging

- New types: `ProjectCustomBuildingValuesPayload`, `ProjectStagedCustomBuildingValuesPayload`, `UpdateProjectCustomBuildingValuesPayload`, `UpdateProjectStagedCustomBuildingValuesPayload`.
- New inputs: `ProjectCustomBuildingValuesInput`, `UpdateProjectCustomBuildingValuesInput`, `UpdateProjectStagedCustomBuildingValuesInput`, `DeleteProjectStagedCustomBuildingValuesInput`.
- New queries: `projectCustomBuildingValues`, `projectStagedCustomBuildingValues`.
- New mutations: `updateProjectCustomBuildingValues`, `updateProjectStagedCustomBuildingValues`, `deleteProjectStagedCustomBuildingValues`.
- `ProjectAsset` adds `stagedBuilding: EnterpriseBuilding`.

### Project lifecycle

- New types: `ProjectsConnection`, `ProjectEdge`, `ProjectCloneJob` (implements `ProjectJob`), `ProjectClonePayload`, `DeleteProjectJob` (implements `ProjectJob`), `ProjectAutocompletePayload`, `ProjectAutocompleteResult`, `ProjectMaps`.
- New inputs: `ProjectFilter`, `CompanyFilter`, `CompanySortFilter`, `ProjectCloneInput`, `ProjectAutocompleteInput`, `ProjectExportJobAssetFilters`, `AddProjectAssetInput`, `DeleteProjectAssetInput`.
- New enum: `ProjectSort`.
- New queries: `projectsConnection`, `companiesConnection`, `projectAsset`.
- New mutations: `deleteProjectAsync`, `addProjectAssetByPlaceID`, `deleteProjectAssetByPlaceID`, `createProjectClone`.
- `Project` gains: `aiInsights`, `assetClass`, `assetCount`, `centroid`, `clonedFromProject`, `complexProperties`, `createdAt`, `maps`, `parentProjectId`, `portfolioAssetDetails`, `portfolioStatus`, `portfolioType`, `vintageId`.
- `ProjectStatus` gains: `CLONING`, `DELETING`, `DELETED`.
- `CreateProjectInput` gains `parentProjectId`.
- `ProjectExportInput` gains `projectExportJobFilters: ProjectExportJobAssetFilters`.
- `RefreshProjectModuleInput` gains `vintageId: Int64`.
- `ProjectExportJobType` gains `EQUITY_OVERVIEW`, `LOCALITY_MACROECONOMIC`, `FULL_PORTFOLIO`.

### Hazard rollup peril (new)

- New types: `AssetClimateExposureHazard`, `AssetHazardDamages`, `AssetHazardDamagesAAL`, `HazardExposureStatistics`, `LinearHazardExposureStatistics`.
- `AssetClimateExposure` gains a `hazard: AssetClimateExposureHazard` field aggregating all perils.
- New `AssetSort` values: `CLIMATE_EXPOSURE_HAZARD_FACTOR_SCORE_ASC` / `_DESC`, `CLIMATE_EXPOSURE_HAZARD_DAMAGE_AAL_*` (ASC/DESC and `_CASH_LOSS_*`, `_INTERRUPTION_*`, `_REPAIR_DAYS_*`).

### Damage outputs expanded (Flood, Wind, Fire)

`AssetFloodDamagesAsset` adds: `interruptionLoss: Int64`, `cashLoss: Int64`, `operatorLoss: Int64`.
`AssetWindDamagesAsset` adds: `interruptionLoss: Int64`, `cashLoss: Int64`, `operatorLoss: Int64`.

New `AssetSort` values for these dimensions: `CLIMATE_EXPOSURE_FLOOD_CASH_LOSS_*`, `CLIMATE_EXPOSURE_FLOOD_INTERRUPTION_LOSS_*`, `CLIMATE_EXPOSURE_FLOOD_LOW_POINT_*`, `CLIMATE_EXPOSURE_FLOOD_DAMAGE_AAL_CASH_LOSS_*`, `CLIMATE_EXPOSURE_FLOOD_DAMAGE_AAL_INTERRUPTION_*`, `CLIMATE_EXPOSURE_FLOOD_DAMAGE_AAL_REPAIR_DAYS_*`, plus the equivalent `WIND_*` and `FIRE_*` variants.

### New peril surfaces (Air, Hail) and exposure statistics

- New types: `FloodExposureStatistics`, `FireExposureStatistics`, `WindExposureStatistics`, `HeatExposureStatistics`, `ColdExposureStatistics`, `DroughtExposureStatistics`, `HazardExposureStatistics`, `RegionalExposure`, plus `Linear*` variants for each (`LinearFloodExposureStatistics`, `LinearFireExposureStatistics`, `LinearWindExposureStatistics`, `LinearHeatExposureStatistics`, `LinearColdExposureStatistics`, `LinearDroughtExposureStatistics`, `LinearHazardExposureStatistics`, `LinearAssetAnalysisData`).
- New input: `RegionalExposureInput`.
- New `AssetSort` values: `CLIMATE_EXPOSURE_AIR_FACTOR_SCORE_ASC` / `_DESC`, `CLIMATE_EXPOSURE_HAIL_FACTOR_SCORE_ASC` / `_DESC`.

### Macroeconomic (new domain)

- New types: `MacroeconomicData`, `LocalityMacroeconomicData`, `ModuleMacroeconomic`, `EconFactorDistribution`, `PerilBucketDistribution`, `BucketStat`.
- New input: `EconFactorDistributionFilter`.
- New `AssetSort` values: extensive `METRO_MACROECONOMIC_*` family covering GDP, GDPPC, population, gross income, price of living, and their `CHANGE_FACTOR_CLIMATE` / `CHANGE_FACTOR_CLIMATE_MARKET` variants (ASC/DESC for each).

### Equity / Company / Industry (new domain)

- New types: `CompanyOverviewData`, `EquityScoreData`, `Industry`, `Sector`, `ModuleCompanyOverview`, `ModuleLinearAssetAnalysis`, `FactorScore`.
- New enum: `InvestmentStage`.
- `Company.industry: Industry` and `Company.sector: Sector` replace the deprecated `industryId` / `sectorId` strings.

### Link sharing (new domain)

- New types: `LinkShare`, `LinkShareEdge`, `LinkSharePayload`, `LinkSharesConnection`, `GenerateLinkSharePayload`, `UpdateLinkSharePayload`.
- New enum: `LinkSharesSort`.
- New inputs: `LinkShareInput`, `GenerateLinkShareInput`, `UpdateLinkShareInput`.
- New queries: `linkShare(input: LinkShareInput!): LinkSharePayload!`, `linkSharesConnection(...)`.
- New mutations: `generateLinkShare`, `linkShare(linkId: String!): LinkShare`, `updateLinkShare`.

### Viewed history (new)

- New types: `ViewedHistoryItem`, `ViewedHistoryList`.
- New enums: `ViewedHistoryItemType`, `ViewedItemsSort`.
- New inputs: `SaveViewHistoryInput`, `EntDeleteViewedHistoryInput`.
- New query: `viewedHistoryList(sort: ViewedItemsSort): ViewedHistoryList`.
- New mutations: `saveViewedHistoryItem`, `deleteViewedHistoryItem`.

### AI Insights (new)

- New types: `AIInsights`, `ModuleOverview` AI summary surfacing.
- New enum: `AIInsightsStatus` (`GENERATING`, `GENERATED`, `FAILED`, `DIRTY`).
- `Project.aiInsights: AIInsights`.

### User & user groups

- New types: `UserGroup`, `UserSubgroup`.
- New input: `DeleteUserDataInput`.
- New query: `userGroup: UserGroup`.
- New mutation: `deleteUserData(input: DeleteUserDataInput!): RequestStatus!`.

### Geospatial primitives (new)

- New types: `BoundingBox`, `Coordinate`, `Feature`, `Map`, `ComplexProperties`.
- New enums: `ComplexType`, `MapStatus`, `OccupancyType`, `AssetStatus`.
- New scalar: `Time`.

### Project asset additions

`ProjectAsset` gains: `buildingMetadata: AssetBuildingMetadata`, `locality: AssetLocality`, `stagedBuilding: EnterpriseBuilding`, `valuechain: AssetValueChain`, `newlyAdded: Boolean`, `deleted: Boolean`, `createdAt: Date`, `geocodeQualityScore: Int`.

`ProjectAssetFilter` gains: `localityFilter`, `localityFilters`, `locationValidated`, `valueChainPosition`.

---

## Migration guide

### 1. Replace `Factor` integers with `factorScore`

**Before**

```graphql
query {
  projectAsset(projectId: 123, placeId: "abc") {
    climateExposure {
      flood { floodFactor factorScale }
      wildfire { fireFactor factorScale }
      wind { windFactor factorScale }
    }
  }
}
```

**After**

```graphql
query {
  projectAsset(projectId: 123, placeId: "abc") {
    climateExposure {
      flood {
        factorScore(filterBy: { ssp: SSP_2_45, relativeYear: 0 }) {
          score
          scale
        }
      }
      wildfire {
        factorScore(filterBy: { ssp: SSP_2_45, relativeYear: 0 }) { score scale }
      }
      wind {
        factorScore(filterBy: { ssp: SSP_2_45, relativeYear: 0 }) { score scale }
      }
    }
  }
}
```

### 2. Replace `AssetSort` factor enums with `_SCORE_` variants

**Before**

```graphql
projectAssetConnection(sort: CLIMATE_EXPOSURE_FLOOD_FACTOR_DESC) { ... }
```

**After**

```graphql
projectAssetConnection(
  sort: CLIMATE_EXPOSURE_FLOOD_FACTOR_SCORE_DESC
  filter: { assetSortingFilter: { ssp: SSP_2_45, relativeYear: 0 } }
) { ... }
```

### 3. Paginate projects with `projectsConnection`

**Before**

```graphql
query { projects { id name } }
```

**After**

```graphql
query {
  projectsConnection(first: 50, sort: CREATED_AT_DESC, filter: { /* ProjectFilter */ }) {
    edges { node { id name } cursor }
    pageInfo { hasNextPage endCursor }
  }
}
```

### 4. Use `projectJobsConnection` instead of `projectJobs`

**Before**

```graphql
query { projectJobs(filter: { projectId: 123 }) { id status } }
```

**After**

```graphql
query {
  projectJobsConnection(first: 50, filter: { projectId: 123 }) {
    edges { node { id status } cursor }
    pageInfo { hasNextPage endCursor }
  }
}
```

### 5. Switch to `deleteProjectAsync`

**Before**

```graphql
mutation { deleteProject(input: { projectId: 123 }) { success } }
```

**After**

```graphql
mutation {
  deleteProjectAsync(input: { projectId: 123 }) {
    id
    status
  }
}
```

The async version returns a `ProjectJob` (specifically `DeleteProjectJob`) that you can poll via `projectJob(projectJobId:)`. The project enters `ProjectStatus.DELETING` and transitions to `DELETED` when the job completes.

### 6. Use `vintageId` instead of `vintage`

**Before**

```graphql
query { project(projectId: 123) { vintage } }
```

**After**

```graphql
query { project(projectId: 123) { vintageId } }
```

`vintageId` is `Int64`; update client types accordingly.

### 7. Use `holdPeriod` instead of `relativeYear` on adaptations

**Before**

```graphql
projectStagedAdaptations(input: { projectId: 123, placeId: "abc" }) {
  type
  relativeYear
}
```

**After**

```graphql
projectStagedAdaptations(input: { projectId: 123, placeId: "abc" }) {
  type
  holdPeriod
}
```

### 8. Replace `Company.industryId` / `sectorId` with the nested objects

**Before**

```graphql
{ company { industryId sectorId } }
```

**After**

```graphql
{ company { industry { id name } sector { id name } } }
```

### 9. Drop obsolete macroeconomic factor fields

The following are now `@deprecated` with reason "This parameter is obsolete." and should be removed from queries: `econFactorClimate`, `econFactorScaleClimate`, `gdpChangeFactor`, `gdppcChangeFactor`, `medianAgeChangeFactor`, `nativeBornPctChangeFactor`, `populationChangeFactor`, `rppiChangeFactor`, `cppiChangeFactor`, `unemploymentChangeFactor`. Use the new `MacroeconomicData` / `LocalityMacroeconomicData` surfaces and the `METRO_MACROECONOMIC_*` sort enum variants instead.

### 10. Avoid `projectAutocomplete`

It is shipped but marked `@deprecated(reason: "WIP")`. Do not depend on its shape; it is subject to change without further notice.

